### PR TITLE
Altered ePub3.xcodeproj build scripts so they can handle spaces in paths

### DIFF
--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -1946,7 +1946,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../..\nsh MakeHeaders.sh Apple";
+			shellScript = "cd \"${SRCROOT}/../..\"\nsh MakeHeaders.sh Apple";
 			showEnvVarsInLog = 0;
 		};
 		AB5D1071172AD540001D3C95 /* ShellScript */ = {
@@ -1960,7 +1960,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../..\nsh MakeHeaders.sh Apple";
+			shellScript = "cd \"${SRCROOT}/../..\"\nsh MakeHeaders.sh Apple";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Without this, attempting to build ePub3.xcodeproj will fail if it's accessible via a path containing a space.