### PR TITLE
Refactor to use WKWebView

### DIFF
--- a/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
@@ -172,7 +172,7 @@ static __weak RDPackageResourceServer *m_packageResourceServer = nil;
         }
         
         response = dataResponse;
-        return dataResponse;
+        return response;
     }
 	
 	// Fake script request, immediately invoked after epubReadingSystem hook is in place,

--- a/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
@@ -149,6 +149,31 @@ static __weak RDPackageResourceServer *m_packageResourceServer = nil;
 			return response;
 		}
 	}
+    
+    if ([path hasPrefix:@"readium-shared-js/"] || [path hasPrefix:@"wkwebview/"] || [path hasSuffix:@"reader.html"]) {
+        NSString* fileName = [[path lastPathComponent] stringByDeletingPathExtension];
+        NSString* extension = [path pathExtension];
+        
+        NSURL* readerURL = [[NSBundle mainBundle] URLForResource:fileName withExtension:extension];
+        if (!readerURL) {
+            readerURL = [[NSBundle mainBundle] URLForResource:fileName
+                                                withExtension:extension
+                                                 subdirectory:[path stringByDeletingLastPathComponent]];
+        }
+        NSData* readerData = [NSData dataWithContentsOfURL:readerURL];
+        RDPackageResourceDataResponse* dataResponse = [[RDPackageResourceDataResponse alloc] initWithData:readerData];
+        
+        if ([extension isEqualToString:@"html"]) {
+            dataResponse.contentType = @"text/html";
+        } else if ([extension isEqualToString:@"css"]) {
+            dataResponse.contentType = @"text/css";
+        } else if ([extension isEqualToString:@"js"]) {
+            dataResponse.contentType = @"text/javascript";
+        }
+        
+        response = dataResponse;
+        return dataResponse;
+    }
 	
 	// Fake script request, immediately invoked after epubReadingSystem hook is in place,
 	// => push the global window.navigator.epubReadingSystem into the iframe(s)


### PR DESCRIPTION
*This is part of a pull request for issue: https://github.com/readium/SDKLauncher-iOS/issues/48*

#### Refactor to use WKWebView
The intention here is to serve up reader.html and the files it includes from the internal http server.  This is to get around CORS issues presented when using mixed protocols (file:// and http://) when using the new WKWebView.