### PR TITLE
Merging the latest fixes related to content length into develop

### DIFF
--- a/ePub3/ePub/filter_chain_byte_stream.cpp
+++ b/ePub3/ePub/filter_chain_byte_stream.cpp
@@ -62,10 +62,13 @@ FilterChainByteStream::FilterChainByteStream(std::unique_ptr<SeekableByteStream>
     {
         m_filters.push_back(filter);
         m_filterContexts.push_back(std::unique_ptr<FilterContext>(filter->MakeFilterContext(manifestItem)));
-
-        if (filter->GetOperatingMode() == ContentFilter::OperatingMode::RequiresCompleteData && !_needs_cache)
-            _needs_cache = true;
     }
+	
+	// We are currently hardcoding _needs_cache to true, because we realized that this is the only way to realiably compute
+	// the content length of any resource being read by FilterChainByteStream. Only by processing the raw conten of a given
+	// resource through all the filters in the chaing, and storing the result in the cache, that we can reliably stablish the
+	// size of the resource after being processed.
+	_needs_cache = true;
 }
 
 ByteStream::size_type FilterChainByteStream::ReadBytes(void* bytes, size_type len)

--- a/ePub3/ePub/filter_chain_byte_stream.cpp
+++ b/ePub3/ePub/filter_chain_byte_stream.cpp
@@ -53,7 +53,7 @@ FilterChainByteStream::~FilterChainByteStream()
 //}
 
 FilterChainByteStream::FilterChainByteStream(std::unique_ptr<SeekableByteStream>&& input, std::vector<ContentFilterPtr>& filters, ConstManifestItemPtr manifestItem)
-: _input(std::move(input)), m_filters(), m_filterContexts(), _needs_cache(false), _cache(), _read_cache()
+: _input(std::move(input)), m_filters(), m_filterContexts(), _needs_cache(false), _cache(), _read_cache(), _cacheHasBeenFilledUp(false)
 {
     _cache.SetUsesSecureErasure();
     _read_cache.SetUsesSecureErasure();
@@ -77,7 +77,7 @@ ByteStream::size_type FilterChainByteStream::ReadBytes(void* bytes, size_type le
 
     if (_needs_cache)
     {
-        if (_cache.GetBufferSize() == 0 && _input->AtEnd() == false)
+        if (_cache.GetBufferSize() == 0 && !_cacheHasBeenFilledUp)
             CacheBytes();
 
         return ReadBytesFromCache(bytes, len);
@@ -267,6 +267,7 @@ void FilterChainByteStream::CacheBytes()
 
         _cache = std::move(_read_cache);
         _read_cache.RemoveBytes(_read_cache.GetBufferSize());
+        _cacheHasBeenFilledUp = true;
     }
 
     // this potentially contains decrypted data, so use secure erasure

--- a/ePub3/ePub/filter_chain_byte_stream.h
+++ b/ePub3/ePub/filter_chain_byte_stream.h
@@ -58,7 +58,7 @@ private:
     FilterChainByteStream&         operator=(FilterChainByteStream&&)                         _DELETED_;
 
 public:
-    FilterChainByteStream() : ByteStream() {}
+    FilterChainByteStream() : ByteStream(), _cacheHasBeenFilledUp(false) {}
     //EPUB3_EXPORT FilterChainByteStream(std::vector<ContentFilterPtr>& filters, ConstManifestItemPtr &manifestItem);
     EPUB3_EXPORT FilterChainByteStream(std::unique_ptr<SeekableByteStream>&& input, std::vector<ContentFilterPtr>& filters, ConstManifestItemPtr manifestItem);
     virtual ~FilterChainByteStream();
@@ -67,7 +67,7 @@ public:
     {
         if (_needs_cache)
 		{
-			if (_cache.GetBufferSize() == 0)
+			if (_cache.GetBufferSize() == 0 && !_cacheHasBeenFilledUp)
 			{
 				CacheBytes();
 			}
@@ -113,6 +113,8 @@ private:
     void CacheBytes();
     size_type FilterBytes(void* bytes, size_type len);
     //size_type FilterBytes(void* bytes, ByteRange &byteRange);
+    
+    bool _cacheHasBeenFilledUp;
 };
 
 EPUB3_END_NAMESPACE

--- a/ePub3/ePub/filter_chain_byte_stream.h
+++ b/ePub3/ePub/filter_chain_byte_stream.h
@@ -63,9 +63,14 @@ public:
     EPUB3_EXPORT FilterChainByteStream(std::unique_ptr<SeekableByteStream>&& input, std::vector<ContentFilterPtr>& filters, ConstManifestItemPtr manifestItem);
     virtual ~FilterChainByteStream();
     
-    virtual size_type BytesAvailable() const _NOEXCEPT OVERRIDE
+    virtual size_type BytesAvailable() _NOEXCEPT OVERRIDE
     {
-        if (_needs_cache && _input->AtEnd()) {
+        if (_needs_cache)
+		{
+			if (_cache.GetBufferSize() == 0)
+			{
+				CacheBytes();
+			}
             return _cache.GetBufferSize();
         } else {
             return _input->BytesAvailable();

--- a/ePub3/ePub/filter_chain_byte_stream_range.cpp
+++ b/ePub3/ePub/filter_chain_byte_stream_range.cpp
@@ -44,7 +44,7 @@ FilterChainByteStreamRange::FilterChainByteStreamRange(std::unique_ptr<SeekableB
 //{
 //}
 
-ByteStream::size_type FilterChainByteStreamRange::BytesAvailable() const _NOEXCEPT
+ByteStream::size_type FilterChainByteStreamRange::BytesAvailable() _NOEXCEPT
 {
     if (m_filter)
     {

--- a/ePub3/ePub/filter_chain_byte_stream_range.h
+++ b/ePub3/ePub/filter_chain_byte_stream_range.h
@@ -54,7 +54,7 @@ public:
     //EPUB3_EXPORT FilterChainByteStreamRange(std::unique_ptr<SeekableByteStream> &&input);
     virtual ~FilterChainByteStreamRange();
     
-    virtual size_type BytesAvailable() const _NOEXCEPT OVERRIDE;
+    virtual size_type BytesAvailable() _NOEXCEPT OVERRIDE;
     virtual size_type SpaceAvailable() const _NOEXCEPT OVERRIDE { return 0; }
     virtual bool IsOpen() const _NOEXCEPT OVERRIDE { return m_input->IsOpen(); }
     virtual void Close() OVERRIDE { m_input->Close(); }

--- a/ePub3/utilities/byte_stream.cpp
+++ b/ePub3/utilities/byte_stream.cpp
@@ -583,7 +583,7 @@ FileByteStream::~FileByteStream()
 {
     Close();
 }
-ByteStream::size_type FileByteStream::BytesAvailable() const _NOEXCEPT
+ByteStream::size_type FileByteStream::BytesAvailable() _NOEXCEPT
 {
     if ( !IsOpen() )
         return 0;
@@ -748,7 +748,7 @@ ZipFileByteStream::~ZipFileByteStream()
 {
     Close();
 }
-ByteStream::size_type ZipFileByteStream::BytesAvailable() const _NOEXCEPT
+ByteStream::size_type ZipFileByteStream::BytesAvailable() _NOEXCEPT
 {
     if ( _file == nullptr )
         return 0;

--- a/ePub3/utilities/byte_stream.h
+++ b/ePub3/utilities/byte_stream.h
@@ -101,7 +101,7 @@ private:
 public:
     ///
     /// Returns the number of bytes that can be read at this time.
-    virtual size_type       BytesAvailable()                        const _NOEXCEPT  { return UnknownSize; }
+    virtual size_type       BytesAvailable()                        _NOEXCEPT  { return UnknownSize; }
     ///
     /// Returns the amount of space available for writing at this time.
     virtual size_type       SpaceAvailable()                        const _NOEXCEPT  { return UnknownSize; }
@@ -274,7 +274,7 @@ public:
     
     ///
     /// @copydoc ByteStream::BytesAvailable()
-    virtual size_type           BytesAvailable()                    const _NOEXCEPT  {
+    virtual size_type           BytesAvailable()                    _NOEXCEPT  {
         return (_readbuf ? _readbuf->BytesAvailable() : 0);
     }
     ///
@@ -491,7 +491,7 @@ private:
 public:
     ///
     /// @copydoc ByteStream::BytesAvailable()
-    virtual size_type       BytesAvailable()                        const _NOEXCEPT;
+    virtual size_type       BytesAvailable()                        _NOEXCEPT;
     ///
     /// @copydoc ByteStream::SpaceAvailable()
     virtual size_type       SpaceAvailable()                        const _NOEXCEPT;
@@ -580,7 +580,7 @@ private:
 public:
     ///
     /// @copydoc ByteStream::BytesAvailable()
-    virtual size_type       BytesAvailable()                        const _NOEXCEPT;
+    virtual size_type       BytesAvailable()                        _NOEXCEPT;
     ///
     /// @copydoc ByteStream::SpaceAvailable
     virtual size_type       SpaceAvailable()                        const _NOEXCEPT;
@@ -678,7 +678,7 @@ public:
     // use the ringbuffer-based availability functions from AsyncByteStream
     ///
     /// @copydoc AsyncByteStream::BytesAvailable
-    virtual size_type       BytesAvailable()    const _NOEXCEPT              { return __A::BytesAvailable(); }
+    virtual size_type       BytesAvailable()    _NOEXCEPT              { return __A::BytesAvailable(); }
     ///
     /// @copydoc AsyncByteStream::SpaceAvailable
     virtual size_type       SpaceAvailable()    const _NOEXCEPT              { return __A::SpaceAvailable(); }
@@ -758,7 +758,7 @@ public:
     // use the ringbuffer-based availability functions from AsyncByteStream
     ///
     /// @copydoc AsyncByteStream::BytesAvailable
-    virtual size_type       BytesAvailable()    const _NOEXCEPT              { return __A::BytesAvailable(); }
+    virtual size_type       BytesAvailable()    _NOEXCEPT              { return __A::BytesAvailable(); }
     ///
     /// @copydoc AsyncByteStream::SpaceAvailable
     virtual size_type       SpaceAvailable()    const _NOEXCEPT              { return __A::SpaceAvailable(); }


### PR DESCRIPTION
This pull request contains all the fixes that I made regarding the content length issues we had. These fixes are essential to allow the Readium SDK to deal properly with encrypted ePUB3 books. They guarantee that the correct content length is reported for both encrypted and unencrypted books, no matter how many ContentFilter objects apply to a given type of resource. These changes came after a technical discussion of those issues and they are the result of a consensus among some of the Readium members.