### PR TITLE
Fix for uncompressed media playback issue in libzip

### DIFF
--- a/ePub3/ThirdParty/libzip/zip_fseek.c
+++ b/ePub3/ThirdParty/libzip/zip_fseek.c
@@ -109,13 +109,14 @@ int _zip_fseek_bytes(struct zip_file* zf, off_t abspos, off_t flen)
     /* CAN set offset past EOF: keeps offset, sets EOF */
     else if (abspos >= flen) {
         zf->flags |= ZIP_ZF_EOF;
-        zf->bytes_left = 0;
+        zf->bytes_left = zf->cbytes_left = 0;
     }
     /* not at or past EOF? ensure EOF is unset and update bytes_left */
     else {
         zf->flags &= ~ZIP_ZF_EOF;
-        zf->bytes_left = flen - abspos;
+        zf->cbytes_left = zf->bytes_left = flen - abspos;
     }
+    zf->fpos += abspos;
     zf->file_fpos = abspos;
     return 0;
 }


### PR DESCRIPTION
I had written the fix in this branch sometime ago. However, instead of taking this fix, I tried to update the libzip code in the Readium SDK to the latest version of that code, given that the libzip Open Source project is still alive and kicking. I discovered a problem, though: libzip evolved too much since we took it in the Readium SDK. The Readium SDK code uses some features that are no longer available in the current version of libzip: they have been replaced for more advanced versions, that would require a whole lot more work to make things work just the same. The problem, then, is that I do not have the time now for all the work that would be required to modify the Readium SDK so that it could use the latest version of the libzip code. On the other hand, we cannot simply leave this issue without a fix. So, I'm proposing that we merge my fix to libzip to develop, so that we unblock ourselves. At a later time, somebody that has the time for that can try again to take the latest libzip code.