### PR TITLE
Allow HEAD requests in RDPackageResourceConnection

### DIFF
--- a/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
@@ -98,7 +98,7 @@ static __weak RDPackageResourceServer *m_packageResourceServer = nil;
 - (NSObject <HTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path {
 	if (m_packageResourceServer == nil ||
 		method == nil ||
-		![method isEqualToString:@"GET"] ||
+		(![method isEqualToString:@"GET"] && ![method isEqualToString:@"HEAD"]) ||
 		path == nil ||
 		path.length == 0)
 	{


### PR DESCRIPTION
A 404 is returned when fetching a resource using a HTTP HEAD request instead of a GET request.
It looks like the underlying HTTPResponse has the ability to process these type of requests, so I don't see a reason why it shouldn't be allowed.

Using a HEAD request is useful in page indexing scenarios.