### PR TITLE
Maven packages

### DIFF
--- a/Platform/Android/README.markdown
+++ b/Platform/Android/README.markdown
@@ -54,8 +54,11 @@ Everything else should be set up appropriately by that script.
 ### Maven Package
 
 Once the `ndk-compile.sh` command above has been executed, the native library
-and Java code can be packaged into standard Java jar archives with the following
-command:
+and Java code can be packaged into standard Maven packages and deployed to
+repositories to be referenced as dependencies from Android applications.
+Assuming that the Android artifacts have been deployed to a local repository
+(with the [maven-android-sdk-deployer](https://github.com/simpligility/maven-android-sdk-deployer),
+for example), packages can be produced with the following command:
 
 ```bash
 $ mvn clean package

--- a/Platform/Android/README.markdown
+++ b/Platform/Android/README.markdown
@@ -51,6 +51,36 @@ ndk-compile.sh build
 
 Everything else should be set up appropriately by that script.
 
+### Maven Package
+
+Once the `ndk-compile.sh` command above has been executed, the native library
+and Java code can be packaged into standard Java jar archives with the following
+command:
+
+```bash
+$ mvn clean package
+```
+
+The created artifacts can then be deployed to any repository (with `mvn deploy`)
+and then referenced from any Android application with the following dependency
+declaration (in Maven syntax, but applicable to any other build system that
+uses Maven packages):
+
+```
+<dependency>
+  <groupId>org.readium</groupId>
+  <artifactId>readium-sdk-android-runtime</artifactId>
+  <version>0.20.0</version>
+</dependency>
+<dependency>
+  <groupId>org.readium</groupId>
+  <artifactId>libepub3</artifactId>
+  <version>0.20.0</version>
+  <classifier>armeabi-v7a</classifier>
+  <type>so</type>
+</dependency>
+```
+
 ### Linux Notes (Ubuntu 13.04 64bit):
 
 

--- a/Platform/Android/libepub3/pom.xml
+++ b/Platform/Android/libepub3/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.readium</groupId>
+    <artifactId>readium-sdk-android</artifactId>
+    <version>0.20.0</version>
+  </parent>
+  <artifactId>libepub3</artifactId>
+
+  <packaging>jar</packaging>
+  <description>Readium SDK (Android API)</description>
+  <url>https://github.com/readium/readium-sdk</url>
+
+  <build>
+    <plugins>
+      <!-- Attach native artifacts -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>../libs/armeabi-v7a/libepub3.so</file>
+                  <type>so</type>
+                  <classifier>armeabi-v7a</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/Platform/Android/pom.xml
+++ b/Platform/Android/pom.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.readium</groupId>
+  <artifactId>readium-sdk-android</artifactId>
+  <version>0.20.0</version>
+
+  <packaging>pom</packaging>
+  <description>Readium SDK (Android API)</description>
+  <url>https://github.com/readium/readium-sdk</url>
+
+  <modules>
+    <module>runtime</module>
+    <module>libepub3</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <prerequisites>
+    <maven>3.2.1</maven>
+  </prerequisites>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>android</groupId>
+        <artifactId>android</artifactId>
+        <version>4.4.2_r4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <!-- Submodule plugin versions -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.6.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+        </plugin>
+
+        <plugin>
+          <groupId>com.simpligility.maven.plugins</groupId>
+          <artifactId>android-maven-plugin</artifactId>
+          <version>4.3.0</version>
+          <extensions>true</extensions>
+        </plugin>
+
+        <!-- Require JDK >= 1.6 -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.3</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+
+        <!-- Produce custom manifest in jar files -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.6</version>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Specification-Title>${project.name}</Specification-Title>
+                <Specification-Version>${project.version}</Specification-Version>
+                <Specification-Vendor>Readium Foundation</Specification-Vendor>
+                <Implementation-Title>${project.name}</Implementation-Title>
+                <Implementation-Version>${project.version}</Implementation-Version>
+                <Implementation-Vendor>Readium Foundation</Implementation-Vendor>
+                <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                <Sealed>true</Sealed>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <!-- Build logic shared to all sub-modules. -->
+    <plugins>
+
+      <!-- Create source jar -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Specification-Title>${project.name}</Specification-Title>
+                  <Specification-Version>${project.version}</Specification-Version>
+                  <Specification-Vendor>Readium Foundation</Specification-Vendor>
+                  <Implementation-Title>${project.name}</Implementation-Title>
+                  <Implementation-Version>${project.version}</Implementation-Version>
+                  <Implementation-Vendor>Readium Foundation</Implementation-Vendor>
+                  <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Javadoc handling -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <bottom><![CDATA[Copyright &#169; {currentYear} &lt;Readium Foundation&gt; http://readium.org]]></bottom>
+              <additionalparam>-Xdoclint:none</additionalparam>
+              <archive>
+                <manifestEntries>
+                  <Specification-Title>${project.name}</Specification-Title>
+                  <Specification-Version>${project.version}</Specification-Version>
+                  <Specification-Vendor>Readium Foundation</Specification-Vendor>
+                  <Implementation-Title>${project.name}</Implementation-Title>
+                  <Implementation-Version>${project.version}</Implementation-Version>
+                  <Implementation-Vendor>Readium Foundation</Implementation-Vendor>
+                  <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Android plugin configuration -->
+      <plugin>
+        <groupId>com.simpligility.maven.plugins</groupId>
+        <artifactId>android-maven-plugin</artifactId>
+        <configuration>
+          <failOnNonStandardStructure>true</failOnNonStandardStructure>
+          <sdk>
+            <platform>19</platform>
+          </sdk>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/Platform/Android/runtime/pom.xml
+++ b/Platform/Android/runtime/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.readium</groupId>
+    <artifactId>readium-sdk-android</artifactId>
+    <version>0.20.0</version>
+  </parent>
+  <artifactId>readium-sdk-android-runtime</artifactId>
+
+  <packaging>jar</packaging>
+  <description>Readium SDK (Android API)</description>
+  <url>https://github.com/readium/readium-sdk</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>android</groupId>
+      <artifactId>android</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>../src/</sourceDirectory>
+  </build>
+
+</project>


### PR DESCRIPTION
This change simply adds a few Maven POM files that will produce standard Java jar files that can be deployed to any Maven repository. This allows anyone using Maven (or a build system that uses Maven packages such as Gradle) to access the Android APIs and native library without having to import sources, or manually attach libraries to their project. They simply declare a dependency in their project files, and their build system fetches and handles all packaging for them.

The change is entirely opt-in: If you don't run Maven, you won't see anything new.
