### PR TITLE
Add setPostFilterPopulationHandler to EPub3 Java API

### DIFF
--- a/Platform/Android/jni/epub3.h
+++ b/Platform/Android/jni/epub3.h
@@ -139,6 +139,13 @@ JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setCachePath(JNIEnv* e
 
 /*
  * Class:     org_readium_sdk_android_EPub3
+ * Method:    setPostFilterPopulationHandler
+ * Signature: (Ljava/lang/Runnable;)V
+ */
+JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setPostFilterPopulationHandler(JNIEnv* env, jobject thiz, jobject handler);
+
+/*
+ * Class:     org_readium_sdk_android_EPub3
  * Method:    isEpub3Book
  * Signature: (Ljava/lang/String;)Z
  */

--- a/Platform/Android/src/org/readium/sdk/android/EPub3.java
+++ b/Platform/Android/src/org/readium/sdk/android/EPub3.java
@@ -120,6 +120,15 @@ public class EPub3 {
 	 */
 	public static native void setCachePath(String cachePath);
 	
+  /**
+   * Sets a handler that will be called after the filter chain
+   * has been populated. This allows the application to
+   * register any additional filters from within the handler.
+   * This needs to be called before any ePub3 library calls.
+   * @param handler The handler that will be called
+   */
+  public static native void setPostFilterPopulationHandler(Runnable handler);
+
 	/**
 	 * Checks if the supplied book is EPUB3. 
 	 * @param path Path to the book.


### PR DESCRIPTION
Add a setPostFilterPopulationHandler method to EPub3 that allows
for a Java callback to be evaluated by Readium after the filter
chain has been populated. This allows for applications to register
any additional required plugins prior to opening a book for the
first time.

This is currently a requirement for anyone using the Adobe Adept
content filter, because the filter must be registered after the filter
chain is populated but prior to the opening of the first book.