### PR TITLE
Make the SDK compatible with Adobe's DRM Connector Content Filter

### DIFF
--- a/Platform/Apple/RDServices/Main/RDContainer.h
+++ b/Platform/Apple/RDServices/Main/RDContainer.h
@@ -35,6 +35,15 @@
 
 - (BOOL)container:(RDContainer *)container handleSdkError:(NSString *)message isSevereEpubError:(BOOL)isSevereEpubError;
 
+@optional
+
+/**
+ * Called just after the container populated the default filters into
+ * the filter manager.
+ * You can implement this to register custom filters.
+ */
+- (void)containerRegisterFilters:(RDContainer *)container;
+
 @end
 
 @class RDPackage;

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -84,6 +84,10 @@
 
 		ePub3::InitializeSdk();
 		ePub3::PopulateFilterManager();
+		
+		if ([delegate respondsToSelector:@selector(containerRegisterFilters:)]) {
+			[delegate containerRegisterFilters:self];
+		}
 
 		m_path = path;
 		m_container = ePub3::Container::OpenContainer(path.UTF8String);

--- a/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceConnection.m
@@ -213,7 +213,6 @@ static __weak RDPackageResourceServer *m_packageResourceServer = nil;
 			{
 				// Can be used to check / debug encoding issues
 				NSString * dataStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-				NSLog(@"XHTML SOURCE: %@", dataStr);
 
 				// FORCE HTML WebView parser
 				//@"application/xhtml+xml"

--- a/Platform/Apple/RDServices/Main/RDPackageResourceResponse.m
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceResponse.m
@@ -51,23 +51,29 @@
 
 
 - (NSDictionary *)httpHeaders {
-	if(m_resource.relativePath) {
-		NSString* ext = [[m_resource.relativePath pathExtension] lowercaseString];
-		if([ext isEqualToString:@"xhtml"] || [ext isEqualToString:@"html"]) {
-			return [NSDictionary dictionaryWithObject:@"application/xhtml+xml" forKey:@"Content-Type"]; // FORCE
-		}
-		else if([ext isEqualToString:@"xml"]) {
-			return [NSDictionary dictionaryWithObject:@"application/xml" forKey:@"Content-Type"]; // FORCE
+	NSString *contentType = m_resource.mimeType;
+
+	// force MIMEType for basic files
+	if (m_resource.relativePath) {
+		NSString *ext = [[m_resource.relativePath pathExtension] lowercaseString];
+		if ([ext isEqualToString:@"xhtml"] || [ext isEqualToString:@"html"]) {
+			contentType = @"application/xhtml+xml";
+		} else if([ext isEqualToString:@"xml"]) {
+			contentType = @"application/xml";
+		} else if ([ext isEqualToString:@"svg"]) {
+			contentType = @"image/svg+xml";
+		} else if ([ext isEqualToString:@"js"]) {
+			contentType = @"text/javascript";
+		} else if ([ext isEqualToString:@"css"]) {
+			contentType = @"text/css";
 		}
 	}
 
-	NSString *contentType = self->m_resource.mimeType;
 	if (contentType) {
 		return @{@"Content-Type": contentType};
 	}
-	else {
-		return @{};
-	}
+	
+	return @{};
 }
 
 

--- a/ePub3/ePub/container.cpp
+++ b/ePub3/ePub/container.cpp
@@ -107,13 +107,6 @@ bool Container::Open(const string& path)
 			_packages.push_back(pkg);
 	}
 
-    auto fm = FilterManager::Instance();
-	for (auto& pkg : _packages)
-	{
-        auto fc = fm->BuildFilterChainForPackage(pkg);
-		pkg->SetFilterChain(fc);
-	}
-
 	return true;
 }
 ContainerPtr Container::OpenContainer(const string &path)

--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -393,7 +393,17 @@ bool Package::Open(const string& path)
 #if _XML_OVERRIDE_SWITCHES
     __setupLibXML();
 #endif
-    auto status = PackageBase::Open(path) && Unpack();
+    auto status = PackageBase::Open(path);
+	
+	if (status) {
+		// We want to setup the content filters chain before unpacking
+		// the package, in case its resources are encrypted.
+		auto fm = FilterManager::Instance();
+		auto fc = fm->BuildFilterChainForPackage(shared_from_this());
+		SetFilterChain(fc);
+		
+		status = Unpack();
+	}
 
     if (status)
     {

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -493,6 +493,7 @@ public:
     
     unique_ptr<ArchiveReader>   ReaderForRelativePath(const string& path)       const;
 
+	// FIXME: this might be obsolete (not in use)
     unique_ptr<ArchiveXmlReader>    XmlReaderForRelativePath(const string& path)    const {
         try { return unique_ptr<ArchiveXmlReader>(new ArchiveXmlReader(ReaderForRelativePath(path))); }
         catch (std::invalid_argument&) { return nullptr; }

--- a/ePub3/utilities/byte_stream.h
+++ b/ePub3/utilities/byte_stream.h
@@ -124,6 +124,45 @@ public:
      @result Returns the number of bytes actually copied into `buf`.
      */
     virtual size_type       ReadBytes(void* buf, size_type len)                     = 0;
+	
+	/**
+	 Read all data from the stream.
+	 @param buf A pointer to a buffer which will be allocated
+	 @result Returns the number of bytes copied into `buf`.
+	 */
+	virtual size_type       ReadAllBytes(void** buf)
+	{
+        unsigned char* resbuf = nullptr;
+        unsigned char* temp;
+        size_t resbuflen = 0;
+        
+        unsigned char rdbuf [4096] = {0};
+        size_t rdbuflen = 4096;
+        std::size_t count = this->ReadBytes(rdbuf, rdbuflen);
+        if(count)
+        {
+            resbuf = (unsigned char*)malloc(count);
+            memcpy(resbuf, rdbuf, count);
+            resbuflen = count;
+        }
+        while(count)
+        {
+            count = this->ReadBytes(rdbuf, rdbuflen);
+            
+            temp = (unsigned char*)malloc(count + resbuflen);
+            memcpy(temp, resbuf, resbuflen);
+            free(resbuf);
+            resbuf = temp;
+            memcpy(resbuf+resbuflen, rdbuf, count);
+            resbuflen += count;
+        }
+		
+		if (resbuflen > 0)
+			*buf = resbuf;
+		
+		return resbuflen;
+	}
+	
     /**
      Write some data to the stream.
      @param buf A buffer containing data to write.


### PR DESCRIPTION
This pull request encompasses a few changes to make Readium compatible with a modified version of Adobe's DRM Connector Content Filter. Thus allowing to decrypt ACS EPUB with Readium without modifying Readium's sources.

If merged in, these changes will allow Adobe to release the RMSDK without including a custom (out-of-date) version of Readium, and be always compatible with the latest version of Readium.