### PR TITLE
Filter the package's navigation tables and other referenced documents before unpacking (fixes #200)

### DIFF
--- a/ePub3/ePub/container.cpp
+++ b/ePub3/ePub/container.cpp
@@ -107,13 +107,6 @@ bool Container::Open(const string& path)
 			_packages.push_back(pkg);
 	}
 
-    auto fm = FilterManager::Instance();
-	for (auto& pkg : _packages)
-	{
-        auto fc = fm->BuildFilterChainForPackage(pkg);
-		pkg->SetFilterChain(fc);
-	}
-
 	return true;
 }
 ContainerPtr Container::OpenContainer(const string &path)

--- a/ePub3/ePub/manifest.cpp
+++ b/ePub3/ePub/manifest.cpp
@@ -22,6 +22,7 @@
 #include "package.h"
 #include "byte_stream.h"
 #include "container.h"
+#include "ePub3/xml/document.h"
 #include REGEX_INCLUDE
 #include <sstream>
 
@@ -242,28 +243,56 @@ shared_ptr<xml::Document> ManifestItem::ReferencedDocument() const
     auto package = this->Owner();
     if ( !package )
         return nullptr;
-    
-    unique_ptr<ArchiveXmlReader> reader = package->XmlReaderForRelativePath(path);
-    if ( !reader )
+	
+    shared_ptr<xml::Document> result(nullptr);
+	
+#if EPUB_USE(LIBXML2)
+    // Sometimes, we want to filter the manifest items through
+    // the content filter chain when unpacking the Package. For
+    // example, with some DRM algorithms, the navigation tables are
+    // encrypted and should be filtered before being parsed.
+    ePub3::ManifestItemPtr manifestRef = std::const_pointer_cast<ManifestItem>(Ptr());
+    if (!manifestRef)
         return nullptr;
-
+	
+    shared_ptr<ByteStream> byteStream = package->GetFilterChainByteStream(manifestRef);
+    if (!byteStream)
+        return nullptr;
+	
+	void *docBuf = nullptr;
+	std::size_t resbuflen = byteStream->ReadAllBytes(&docBuf);
+	
+    int flags = XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR;
+	
     // In some EPUBs, UTF-8 XML/HTML files have a superfluous (erroneous?) BOM, so we either:
     // pass "utf-8" and expect InputBuffer::read_cb (in io.cpp) to skip the 3 erroneous bytes
     // (otherwise the XML parser fails),
     // or we pass NULL (in which case the parser auto-detects encoding)
     const char * encoding = nullptr;
     //const char * encoding = "utf-8";
-
-    shared_ptr<xml::Document> result(nullptr);
-#if EPUB_USE(LIBXML2)
-    int flags = XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR;
-    if ( _mediaType == "text/html" )
-        result = reader->htmlReadDocument(path.c_str(), encoding, flags);
-    else
-        result = reader->xmlReadDocument(path.c_str(), encoding, flags);
+	
+	xmlDocPtr raw;
+    if ( _mediaType == "text/html" ) {
+        raw = htmlReadMemory((const char*)docBuf, resbuflen, path.c_str(), encoding, flags);
+    } else {
+        raw = xmlReadMemory((const char*)docBuf, resbuflen, path.c_str(), encoding, flags);
+    }
+	
+	result = xml::Wrapped<xml::Document>(raw);
+	
+    if (docBuf)
+        free(docBuf);
+	
 #elif EPUB_USE(WIN_XML)
-	result = reader->ReadDocument(path.c_str(), "utf-8", 0);
+	// TODO: filtering referenced document through Content Filters
+	// is not yet supported on Windows
+    unique_ptr<ArchiveXmlReader> reader = package->XmlReaderForRelativePath(path);
+    if ( !reader )
+        return nullptr;
+	
+    result = reader->ReadDocument(path.c_str(), "utf-8", 0);
 #endif
+	
     return result;
 }
 unique_ptr<ByteStream> ManifestItem::Reader() const

--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -393,7 +393,19 @@ bool Package::Open(const string& path)
 #if _XML_OVERRIDE_SWITCHES
     __setupLibXML();
 #endif
-    auto status = PackageBase::Open(path) && Unpack();
+    auto status = PackageBase::Open(path);
+	
+	if (status) {
+        // Setup the content filter chain before unpacking the package
+        // to filter its manifest items if needed. For example with
+        // some encrypted EPUB the navigation tables must be decrypted
+        // before being parsed.
+		auto fm = FilterManager::Instance();
+		auto fc = fm->BuildFilterChainForPackage(shared_from_this());
+		SetFilterChain(fc);
+		
+		status = Unpack();
+	}
 
     if (status)
     {

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -493,6 +493,7 @@ public:
     
     unique_ptr<ArchiveReader>   ReaderForRelativePath(const string& path)       const;
 
+	// FIXME: this might be obsolete (not in use)
     unique_ptr<ArchiveXmlReader>    XmlReaderForRelativePath(const string& path)    const {
         try { return unique_ptr<ArchiveXmlReader>(new ArchiveXmlReader(ReaderForRelativePath(path))); }
         catch (std::invalid_argument&) { return nullptr; }

--- a/ePub3/utilities/byte_stream.h
+++ b/ePub3/utilities/byte_stream.h
@@ -124,6 +124,45 @@ public:
      @result Returns the number of bytes actually copied into `buf`.
      */
     virtual size_type       ReadBytes(void* buf, size_type len)                     = 0;
+	
+	/**
+	 Read all data from the stream.
+	 @param buf A pointer to a buffer which will be allocated
+	 @result Returns the number of bytes copied into `buf`.
+	 */
+	virtual size_type       ReadAllBytes(void** buf)
+	{
+        unsigned char* resbuf = nullptr;
+        unsigned char* temp;
+        size_t resbuflen = 0;
+        
+        unsigned char rdbuf [4096] = {0};
+        size_t rdbuflen = 4096;
+        std::size_t count = this->ReadBytes(rdbuf, rdbuflen);
+        if(count)
+        {
+            resbuf = (unsigned char*)malloc(count);
+            memcpy(resbuf, rdbuf, count);
+            resbuflen = count;
+        }
+        while(count)
+        {
+            count = this->ReadBytes(rdbuf, rdbuflen);
+            
+            temp = (unsigned char*)malloc(count + resbuflen);
+            memcpy(temp, resbuf, resbuflen);
+            free(resbuf);
+            resbuf = temp;
+            memcpy(resbuf+resbuflen, rdbuf, count);
+            resbuflen += count;
+        }
+		
+		if (resbuflen > 0)
+			*buf = resbuf;
+		
+		return resbuflen;
+	}
+	
     /**
      Write some data to the stream.
      @param buf A buffer containing data to write.


### PR DESCRIPTION
Filter the package's navigation tables and other referenced documents through the content filter chain before unpacking. The changes are a subset of the pull request #195.

This is used to support encrypted EPUB3 Navigation Document or other XHTML / XML files (issue #200).

Beware! This fix is only for UNIX. A TODO marks the place where the missing Windows code should be.