### PR TITLE
Forbid network access when reading XML documents (causing timeout for DTD)

### DIFF
--- a/ePub3/ePub/archive_xml.cpp
+++ b/ePub3/ePub/archive_xml.cpp
@@ -25,6 +25,8 @@
 
 EPUB3_BEGIN_NAMESPACE
 
+const int ArchiveXmlReader::DEFAULT_OPTIONS = XML_PARSE_RECOVER | XML_PARSE_NOENT | XML_PARSE_DTDATTR | XML_PARSE_NONET;
+
 ArchiveXmlReader::ArchiveXmlReader(ArchiveReader * r) : _reader(r)
 {
     if ( _reader == nullptr )
@@ -56,6 +58,16 @@ size_t ArchiveXmlReader::read(uint8_t *buf, size_t len)
 bool ArchiveXmlReader::close()
 {
     return true;
+}
+
+std::shared_ptr<xml::Document> ArchiveXmlReader::xmlReadDocument(const char * url, const char * encoding)
+{
+	return InputBuffer::xmlReadDocument(url, encoding, ArchiveXmlReader::DEFAULT_OPTIONS);
+}
+
+std::shared_ptr<xml::Document> ArchiveXmlReader::htmlReadDocument(const char * url, const char * encoding)
+{
+	return InputBuffer::htmlReadDocument(url, encoding, ArchiveXmlReader::DEFAULT_OPTIONS);
 }
 
 ArchiveXmlWriter::ArchiveXmlWriter(ArchiveWriter* w) : _writer(w)

--- a/ePub3/ePub/archive_xml.h
+++ b/ePub3/ePub/archive_xml.h
@@ -34,6 +34,17 @@ EPUB3_BEGIN_NAMESPACE
 class ArchiveXmlReader : public xml::InputBuffer
 {
 public:
+	/**
+	 * The default options when reading XML documents from EPUB 3
+	 * archives. To use with xmlReadDocument().
+	 *
+	 *   XML_PARSE_RECOVER: Recover on errors
+	 *   XML_PARSE_NOENT:   Substitute entities
+	 *   XML_PARSE_DTDATTR: Default DTD attributes
+	 *   XML_PARSE_NONET:   Forbid network access (ie. when loading DTD)
+	 */
+    static const int DEFAULT_OPTIONS;
+    
     EPUB3_EXPORT ArchiveXmlReader(ArchiveReader * r);
     EPUB3_EXPORT ArchiveXmlReader(unique_ptr<ArchiveReader>&& r);
     EPUB3_EXPORT ArchiveXmlReader(ArchiveXmlReader&& o);
@@ -46,6 +57,16 @@ public:
 	virtual size_t offset() const { return _reader->position(); }
     
     bool operator !() const { return !bool(_reader); }
+	
+	using InputBuffer::xmlReadDocument;
+	using InputBuffer::htmlReadDocument;
+	
+	/**
+	 * Will read the given XML documents using the default options
+	 * from ArchiveXmlReader::DEFAULT_OPTIONS.
+	 */
+	std::shared_ptr<xml::Document> xmlReadDocument(const char * url, const char * encoding);
+    std::shared_ptr<xml::Document> htmlReadDocument(const char * url, const char * encoding);
     
 protected:
     std::unique_ptr<ArchiveReader>  _reader;

--- a/ePub3/ePub/container.cpp
+++ b/ePub3/ePub/container.cpp
@@ -69,8 +69,9 @@ bool Container::Open(const string& path)
 	if (!reader) {
 		throw std::invalid_argument(_Str("Path does not point to a recognised archive file: '", path, "'"));
 	}
+    
 #if EPUB_USE(LIBXML2)
-	_ocf = reader.xmlReadDocument(gContainerFilePath, nullptr, XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR);
+	_ocf = reader.xmlReadDocument(gContainerFilePath, nullptr);
 #else
 	decltype(_ocf) __tmp(reader.ReadDocument(gContainerFilePath, nullptr, /*RESOLVE_EXTERNALS*/ 1));
 	_ocf = __tmp;
@@ -229,7 +230,7 @@ void Container::ParseVendorMetadata()
 
     ArchiveXmlReader reader(std::move(pZipReader));
 #if EPUB_USE(LIBXML2)
-    shared_ptr<xml::Document> docXml = reader.xmlReadDocument(gAppleiBooksDisplayOptionsFilePath, nullptr, XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR);
+    shared_ptr<xml::Document> docXml = reader.xmlReadDocument(gAppleiBooksDisplayOptionsFilePath, nullptr);
 #elif EPUB_USE(WIN_XML)
 	auto docXml = reader.ReadDocument(gAppleiBooksDisplayOptionsFilePath, nullptr, 0);
 #endif
@@ -276,7 +277,7 @@ void Container::LoadEncryption()
     
     ArchiveXmlReader reader(std::move(pZipReader));
 #if EPUB_USE(LIBXML2)
-    shared_ptr<xml::Document> enc = reader.xmlReadDocument(gEncryptionFilePath, nullptr, XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR);
+    shared_ptr<xml::Document> enc = reader.xmlReadDocument(gEncryptionFilePath, nullptr);
 #elif EPUB_USE(WIN_XML)
 	auto enc = reader.ReadDocument(gEncryptionFilePath, nullptr, 0);
 #endif

--- a/ePub3/ePub/manifest.cpp
+++ b/ePub3/ePub/manifest.cpp
@@ -256,11 +256,10 @@ shared_ptr<xml::Document> ManifestItem::ReferencedDocument() const
 
     shared_ptr<xml::Document> result(nullptr);
 #if EPUB_USE(LIBXML2)
-    int flags = XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR;
     if ( _mediaType == "text/html" )
-        result = reader->htmlReadDocument(path.c_str(), encoding, flags);
+        result = reader->htmlReadDocument(path.c_str(), encoding);
     else
-        result = reader->xmlReadDocument(path.c_str(), encoding, flags);
+        result = reader->xmlReadDocument(path.c_str(), encoding);
 #elif EPUB_USE(WIN_XML)
 	result = reader->ReadDocument(path.c_str(), "utf-8", 0);
 #endif

--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -102,7 +102,7 @@ bool PackageBase::Open(const string& path)
 {
     ArchiveXmlReader reader(_archive->ReaderAtPath(path.stl_str()));
 #if EPUB_USE(LIBXML2)
-    _opf = reader.xmlReadDocument(path.c_str(), nullptr, XML_PARSE_RECOVER|XML_PARSE_NOENT|XML_PARSE_DTDATTR);
+    _opf = reader.xmlReadDocument(path.c_str(), nullptr);
 #elif EPUB_USE(WIN_XML)
 	_opf = reader.ReadDocument(path.c_str(), nullptr, 0);
 #endif


### PR DESCRIPTION
Forbid network access when reading XML documents.

Use case: open a book without Internet on your device. When reading the XML files of the package, the XML parser will try to download the external links, like DTD URI. This causes a timeout and a slow book opening. The XML_PARSE_NONET option fixes this.

I did a bit of refactoring too because the flags were duplicated in several different places.

We are using this in Mantano Reader since a few months without any known issue.