### PR TITLE
Populate custom C++ content filters on-the-fly by iOS or Android host apps

### DIFF
--- a/Platform/Android/jni/epub3.cpp
+++ b/Platform/Android/jni/epub3.cpp
@@ -245,20 +245,20 @@ static bool LauncherErrorHandler(const ePub3::error_details& err)
  */
 static void initializeReadiumSDK(JNIEnv* env)
 {
-  m_env = env;
+    m_env = env;
 
 	LOGD("initializeReadiumSDK(): initializing Readium SDK...");
 
-  ePub3::ErrorHandlerFn launcherErrorHandler = LauncherErrorHandler;
-  ePub3::SetErrorHandler(launcherErrorHandler);
+    ePub3::ErrorHandlerFn launcherErrorHandler = LauncherErrorHandler;
+    ePub3::SetErrorHandler(launcherErrorHandler);
 
-  ePub3::InitializeSdk();
-  ePub3::PopulateFilterManager();
+    ePub3::InitializeSdk();
+    ePub3::PopulateFilterManager();
 
-  if (postFilterPopulateHandler != NULL) {
-    LOGD("initializeReadiumSDK(): calling post filter handler %p", postFilterPopulateHandler);
-    env->CallVoidMethod(postFilterPopulateHandler, postFilterPopulateHandler_Run_ID);
-  }
+    if (postFilterPopulateHandler != NULL) {
+        LOGD("initializeReadiumSDK(): calling post filter handler %p", postFilterPopulateHandler);
+        env->CallVoidMethod(postFilterPopulateHandler, postFilterPopulateHandler_Run_ID);
+    }
 
 	LOGD("initializeReadiumSDK(): initialization of Readium SDK finished");
 }
@@ -372,27 +372,27 @@ Java_org_readium_sdk_android_EPub3_setCachePath(JNIEnv* env, jobject thiz, jstri
 JNIEXPORT void JNICALL
 Java_org_readium_sdk_android_EPub3_setPostFilterPopulationHandler(JNIEnv* env, jobject thiz, jobject handler) {
 
-  LOGD("EPub3.setPostFilterPopulationHandler(): received handler object %p", handler);
-  if (handler != NULL) {
+    LOGD("EPub3.setPostFilterPopulationHandler(): received handler object %p", handler);
+    if (handler != NULL) {
+        /**
+         * Save a global reference to the handler object and attempt to find a void-returning
+         * parameterless method on it called 'run'.
+         */
 
-    /**
-     * Save a global reference to the handler object and attempt to find a void-returning
-     * parameterless method on it called 'run'.
-     */
+        jobject hg = env->NewGlobalRef(handler);
+        jclass rc = env->GetObjectClass(hg);
+        jmethodID m = env->GetMethodID(rc, "run", "()V");
+        
+        if (m == NULL) {
+            LOGE("EPub3.setPostFilterPopulationHandler(): could not find 'run' method on handler class");
+            env->DeleteGlobalRef (hg);
+            return;
+        }
 
-    jobject hg = env->NewGlobalRef(handler);
-    jclass rc = env->GetObjectClass(hg);
-    jmethodID m = env->GetMethodID(rc, "run", "()V");
-    if (m == NULL) {
-      LOGE("EPub3.setPostFilterPopulationHandler(): could not find 'run' method on handler class");
-      env->DeleteGlobalRef (hg);
-      return;
+        LOGD("EPub3.setPostFilterPopulationHandler(): saved object %p, method %p", hg, m);
+        postFilterPopulateHandler = hg;
+        postFilterPopulateHandler_Run_ID = m;
     }
-
-    LOGD("EPub3.setPostFilterPopulationHandler(): saved object %p, method %p", hg, m);
-    postFilterPopulateHandler = hg;
-    postFilterPopulateHandler_Run_ID = m;
-  }
 }
 
 /*

--- a/Platform/Android/jni/epub3.cpp
+++ b/Platform/Android/jni/epub3.cpp
@@ -104,14 +104,14 @@ jmethodID addManifestItemToList_ID;
  */
 
 static jclass javaEPub3Class = NULL;
-static jobject postFilterPopulateHandler = NULL;
+static jobject contentFiltersRegistrationHandler = NULL;
 
 static jmethodID createStringList_ID;
 static jmethodID addStringToList_ID;
 static jmethodID createBuffer_ID;
 static jmethodID appendBytesToBuffer_ID;
 static jmethodID handleSdkError_ID;
-static jmethodID postFilterPopulateHandler_Run_ID;
+static jmethodID contentFiltersRegistrationHandler_Run_ID;
 
 
 /*
@@ -255,9 +255,9 @@ static void initializeReadiumSDK(JNIEnv* env)
     ePub3::InitializeSdk();
     ePub3::PopulateFilterManager();
 
-    if (postFilterPopulateHandler != NULL) {
-        LOGD("initializeReadiumSDK(): calling post filter handler %p", postFilterPopulateHandler);
-        env->CallVoidMethod(postFilterPopulateHandler, postFilterPopulateHandler_Run_ID);
+    if (contentFiltersRegistrationHandler != NULL) {
+        LOGD("initializeReadiumSDK(): calling content filters registration handler %p", contentFiltersRegistrationHandler);
+        env->CallVoidMethod(contentFiltersRegistrationHandler, contentFiltersRegistrationHandler_Run_ID);
     }
 
 	LOGD("initializeReadiumSDK(): initialization of Readium SDK finished");
@@ -366,13 +366,13 @@ Java_org_readium_sdk_android_EPub3_setCachePath(JNIEnv* env, jobject thiz, jstri
 
 /*
  * Class:     org_readium_sdk_android_EPub3
- * Method:    setPostFilterPopulationHandler
+ * Method:    setContentFiltersRegistrationHandler
  * Signature: (Ljava/lang/Runnable;)V
  */
 JNIEXPORT void JNICALL
-Java_org_readium_sdk_android_EPub3_setPostFilterPopulationHandler(JNIEnv* env, jobject thiz, jobject handler) {
+Java_org_readium_sdk_android_EPub3_setContentFiltersRegistrationHandler(JNIEnv* env, jobject thiz, jobject handler) {
 
-    LOGD("EPub3.setPostFilterPopulationHandler(): received handler object %p", handler);
+    LOGD("EPub3.setContentFiltersRegistrationHandler(): received handler object %p", handler);
     if (handler != NULL) {
         /**
          * Save a global reference to the handler object and attempt to find a void-returning
@@ -384,14 +384,14 @@ Java_org_readium_sdk_android_EPub3_setPostFilterPopulationHandler(JNIEnv* env, j
         jmethodID m = env->GetMethodID(rc, "run", "()V");
         
         if (m == NULL) {
-            LOGE("EPub3.setPostFilterPopulationHandler(): could not find 'run' method on handler class");
+            LOGE("EPub3.setContentFiltersRegistrationHandler(): could not find 'run' method on handler class");
             env->DeleteGlobalRef (hg);
             return;
         }
 
-        LOGD("EPub3.setPostFilterPopulationHandler(): saved object %p, method %p", hg, m);
-        postFilterPopulateHandler = hg;
-        postFilterPopulateHandler_Run_ID = m;
+        LOGD("EPub3.setContentFiltersRegistrationHandler(): saved object %p, method %p", hg, m);
+        contentFiltersRegistrationHandler = hg;
+        contentFiltersRegistrationHandler_Run_ID = m;
     }
 }
 

--- a/Platform/Android/jni/epub3.h
+++ b/Platform/Android/jni/epub3.h
@@ -139,10 +139,10 @@ JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setCachePath(JNIEnv* e
 
 /*
  * Class:     org_readium_sdk_android_EPub3
- * Method:    setPostFilterPopulationHandler
+ * Method:    setContentFiltersRegistrationHandler
  * Signature: (Ljava/lang/Runnable;)V
  */
-JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setPostFilterPopulationHandler(JNIEnv* env, jobject thiz, jobject handler);
+JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setContentFiltersRegistrationHandler(JNIEnv* env, jobject thiz, jobject handler);
 
 /*
  * Class:     org_readium_sdk_android_EPub3

--- a/Platform/Android/jni/epub3.h
+++ b/Platform/Android/jni/epub3.h
@@ -139,6 +139,13 @@ JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setCachePath(JNIEnv* e
 
 /*
  * Class:     org_readium_sdk_android_EPub3
+ * Method:    setPostFilterPopulationHandler
+ * Signature: (Ljava/lang/Runnable;)V
+ */
+JNIEXPORT void JNICALL Java_org_readium_sdk_android_EPub3_setPostFilterPopulationHandler(JNIEnv* env, jobject thiz, jobject handler);
+
+/*
+ * Class:     org_readium_sdk_android_EPub3
  * Method:    isEpub3Book
  * Signature: (Ljava/lang/String;)Z
  */

--- a/Platform/Android/src/org/readium/sdk/android/EPub3.java
+++ b/Platform/Android/src/org/readium/sdk/android/EPub3.java
@@ -41,7 +41,7 @@ public class EPub3 {
 	 */
 	static {
 		// Load the ePub3 Native lib
-        System.loadLibrary("epub3");
+		System.loadLibrary("epub3");
 	}
 	
 	
@@ -107,9 +107,9 @@ public class EPub3 {
 	}
 	
 	
-    /*
-     * Static native JNI exported methods
-     */
+	/*
+	 * Static native JNI exported methods
+	 */
 	
 	/**
 	 * Sets the core ePub3 SDK cache path, where it can
@@ -120,14 +120,14 @@ public class EPub3 {
 	 */
 	public static native void setCachePath(String cachePath);
 	
-  /**
-   * Sets a handler that will be called after the filter chain
-   * has been populated. This allows the application to
-   * register any additional filters from within the handler.
-   * This needs to be called before any ePub3 library calls.
-   * @param handler The handler that will be called
-   */
-  public static native void setPostFilterPopulationHandler(Runnable handler);
+	/**
+	 * Sets a handler that will be called after the filter chain
+	 * has been populated. This allows the application to
+	 * register any additional filters from within the handler.
+	 * This needs to be called before any ePub3 library calls.
+	 * @param handler The handler that will be called
+	 */
+	public static native void setPostFilterPopulationHandler(Runnable handler);
 
 	/**
 	 * Checks if the supplied book is EPUB3. 
@@ -163,19 +163,19 @@ public class EPub3 {
 		container.close();
 	}
 
-    public static SdkErrorHandler m_SdkErrorHandler = null;
-    public static void setSdkErrorHandler(SdkErrorHandler sdkErrorHandler) {
-        m_SdkErrorHandler = sdkErrorHandler;
-    }
+	public static SdkErrorHandler m_SdkErrorHandler = null;
+	public static void setSdkErrorHandler(SdkErrorHandler sdkErrorHandler) {
+		m_SdkErrorHandler = sdkErrorHandler;
+	}
 
 	private static boolean handleSdkError(String message, boolean isSevereEpubError) {
-        if (m_SdkErrorHandler != null) {
-            return m_SdkErrorHandler.handleSdkError(message, isSevereEpubError);
-        }
-            
-        System.out.println("!SdkErrorHandler: " + message + " (" + (isSevereEpubError ? "warning" : "info") + ")");
+		if (m_SdkErrorHandler != null) {
+			return m_SdkErrorHandler.handleSdkError(message, isSevereEpubError);
+		}
+			
+		System.out.println("!SdkErrorHandler: " + message + " (" + (isSevereEpubError ? "warning" : "info") + ")");
 
-    	// never throws an exception
-    	return true;
+		// never throws an exception
+		return true;
 	}
 }

--- a/Platform/Android/src/org/readium/sdk/android/EPub3.java
+++ b/Platform/Android/src/org/readium/sdk/android/EPub3.java
@@ -127,7 +127,7 @@ public class EPub3 {
 	 * This needs to be called before any ePub3 library calls.
 	 * @param handler The handler that will be called
 	 */
-	public static native void setPostFilterPopulationHandler(Runnable handler);
+	public static native void setContentFiltersRegistrationHandler(Runnable handler);
 
 	/**
 	 * Checks if the supplied book is EPUB3. 

--- a/Platform/Android/src/org/readium/sdk/android/EPub3.java
+++ b/Platform/Android/src/org/readium/sdk/android/EPub3.java
@@ -120,6 +120,15 @@ public class EPub3 {
 	 */
 	public static native void setCachePath(String cachePath);
 	
+  /**
+   * Sets a handler that will be called after the filter chain
+   * has been populated. This allows the application to
+   * register any additional filters from within the handler.
+   * This needs to be called before any ePub3 library calls.
+   * @param handler The handler that will be called
+   */
+  public static native void setPostFilterPopulationHandler(Runnable handler);
+
 	/**
 	 * Checks if the supplied book is EPUB3. 
 	 * @param path Path to the book.

--- a/Platform/Apple/RDServices/Main/RDContainer.h
+++ b/Platform/Apple/RDServices/Main/RDContainer.h
@@ -35,6 +35,15 @@
 
 - (BOOL)container:(RDContainer *)container handleSdkError:(NSString *)message isSevereEpubError:(BOOL)isSevereEpubError;
 
+@optional
+
+/**
+ * Called just after the container populated the default filters into
+ * the filter manager.
+ * You can implement this to register custom filters.
+ */
+- (void)containerRegisterFilters:(RDContainer *)container;
+
 @end
 
 @class RDPackage;

--- a/Platform/Apple/RDServices/Main/RDContainer.h
+++ b/Platform/Apple/RDServices/Main/RDContainer.h
@@ -42,7 +42,7 @@
  * the filter manager.
  * You can implement this to register custom filters.
  */
-- (void)containerRegisterFilters:(RDContainer *)container;
+- (void)containerRegisterContentFilters:(RDContainer *)container;
 
 @end
 

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -84,6 +84,10 @@
 
 		ePub3::InitializeSdk();
 		ePub3::PopulateFilterManager();
+		
+		if ([delegate respondsToSelector:@selector(containerRegisterFilters:)]) {
+			[delegate containerRegisterFilters:self];
+		}
 
 		m_path = path;
 		m_container = ePub3::Container::OpenContainer(path.UTF8String);

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -85,8 +85,8 @@
 		ePub3::InitializeSdk();
 		ePub3::PopulateFilterManager();
 		
-		if ([delegate respondsToSelector:@selector(containerRegisterFilters:)]) {
-			[delegate containerRegisterFilters:self];
+		if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
+			[delegate containerRegisterContentFilters:self];
 		}
 
 		m_path = path;


### PR DESCRIPTION
These additions have no impact whatsoever on existing behavior. It is just an entry-point for host apps (iOS and Android) to plug in custom C++ content filters on-the-fly, without modifying the sources of readium-sdk (PopulateFilterManager() in initialization.cpp). It's a step in the direction of having a more extensible SDK.

The Android part was made by io7m, original PR #194.
The iOS part was extracted from the more general PR #195.

I merged the two because the feature is similar.

This fixes issue #203, but for iOS and Android only.