### PR TITLE
Expose EPUB 2 properties from the OPF package for backward compatibility

### DIFF
--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -731,6 +731,15 @@ bool Package::Unpack()
             }
             else if ( _getProp(node, "name").size() > 0 )
             {
+                // It's an EPUB 2 property, we save them to allow
+                // backward compatiblity by host apps.
+                string name = _getProp(node, "name");
+                string content = _getProp(node, "content");
+#if EPUB_HAVE(CXX_MAP_EMPLACE)
+	                _EPUB2Properties.emplace(name, content);
+#else
+	                _EPUB2Properties[name] = content;
+#endif
                 // it's an ePub2 item-- ignore it
                 continue;
             }
@@ -1822,6 +1831,17 @@ void Package::InitMediaSupport()
         }
     }
 }
+
+string Package::EPUB2PropertyMatching(string name) const
+{
+    auto found = _EPUB2Properties.find(name);
+    if (found != _EPUB2Properties.end()) {
+        return found->second;
+    }
+
+    return string::EmptyString;
+}
+
 void Package::CompileSpineItemTitles()
 {
 	NavigationTablePtr toc = TableOfContents();

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -352,6 +352,14 @@ public:
      */
     typedef std::map<string, MediaSupportInfoPtr>	MediaSupportList;
     
+    /**
+     Map of EPUB 2 properties for backward compatibility.
+     The keys are the properties names and the values are their
+     content.
+     eg. <meta name="cover" content="cover.png"/>
+     */
+    typedef std::map<string, string> EPUB2PropertyList;
+    
 private:
                             Package()                                   _DELETED_;
                             Package(const Package&)                     _DELETED_;
@@ -875,6 +883,13 @@ public:
     virtual void            SetMediaSupport(MediaSupportList&& list);
     
     /**
+     Returns the value (content) of the EPUB 2 property with given
+     name. Used to provide backward compatibility by host app.
+     @param name Name of the property (name attribute of the <meta> tag)
+     */
+    virtual string          EPUB2PropertyMatching(string name) const;
+    
+    /**
      Assigns a filter chain to this package.
      
      This is called automatically by Container at the end of its initialization. The
@@ -917,6 +932,7 @@ public:
 protected:
     LoadEventHandler        _loadEventHandler;      ///< The current handler for load events.
     MediaSupportList        _mediaSupport;          ///< A list of media types with their support details.
+    EPUB2PropertyList       _EPUB2Properties;       ///< A list of EPUB 2 properties for backward compatibility.
     
     void                    InitMediaSupport();
     


### PR DESCRIPTION
Basically offer a way to query the EPUB 2 properties from an OPF file.

Example of an EPUB 2 property: ```<meta name="cover" content="cover.png"/>```.

This can be used to provide backward compatibility for EPUB 2 books from host app, or other features in readium-sdk. For example, the PR #207 which expose the book cover uses this to get either the EPUB 3 or 2 cover.