### PR TITLE
Retrieve the manifest item of the package's cover, if available

### DIFF
--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -1580,6 +1580,18 @@ const string& Package::Language() const
         return string::EmptyString;
     return items[0]->Value();
 }
+shared_ptr<ManifestItem> Package::CoverManifestItem() const
+{
+    string EPUB2CoverID = EPUB2PropertyMatching(string("cover"));
+    for (auto& item : _manifest)
+    {
+        if (item.second->HasProperty(ePub3::ItemProperties::CoverImage) || (EPUB2CoverID.empty() && item.second->Identifier() == EPUB2CoverID)) {
+            return item.second;
+        }
+    }
+
+    return nullptr;
+}
 const string& Package::MediaOverlays_ActiveClass() const
 {
     // See:

--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -1585,7 +1585,7 @@ shared_ptr<ManifestItem> Package::CoverManifestItem() const
     string EPUB2CoverID = EPUB2PropertyMatching(string("cover"));
     for (auto& item : _manifest)
     {
-        if (item.second->HasProperty(ePub3::ItemProperties::CoverImage) || (EPUB2CoverID.empty() && item.second->Identifier() == EPUB2CoverID)) {
+        if (item.second->HasProperty(ePub3::ItemProperties::CoverImage) || item.second->Identifier() == EPUB2CoverID) {
             return item.second;
         }
     }

--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -731,6 +731,15 @@ bool Package::Unpack()
             }
             else if ( _getProp(node, "name").size() > 0 )
             {
+                // It's an EPUB 2 property, we save them to allow
+                // backward compatiblity by host apps.
+                string name = _getProp(node, "name");
+                string content = _getProp(node, "content");
+#if EPUB_HAVE(CXX_MAP_EMPLACE)
+	                _EPUB2Properties.emplace(name, content);
+#else
+	                _EPUB2Properties[name] = content;
+#endif
                 // it's an ePub2 item-- ignore it
                 continue;
             }
@@ -1822,6 +1831,17 @@ void Package::InitMediaSupport()
         }
     }
 }
+
+string Package::EPUB2PropertyMatching(string name) const
+{
+    auto found = _EPUB2Properties.find(name);
+    if (found != _EPUB2Properties.end()) {
+        return found->second;
+    }
+
+    return string::EmptyString;
+}
+
 void Package::CompileSpineItemTitles()
 {
 	NavigationTablePtr toc = TableOfContents();

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -721,6 +721,14 @@ public:
      */
     EPUB3_EXPORT
     const string&           Language()                              const;
+    
+    /**
+     Retrieves the manifest item that is declared as cover for the
+     book, if available. Compatible with EPUB 2 and 3 covers.
+     @result A ManifestItem pointer, or `nullptr` if no manifest item is the cover
+     */
+    EPUB3_EXPORT
+    shared_ptr<ManifestItem> CoverManifestItem() const;
 
     /**
      Retrieves the Media Overlays media:active-class (may be empty string, if unspecified in the OPF package)

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -352,6 +352,14 @@ public:
      */
     typedef std::map<string, MediaSupportInfoPtr>	MediaSupportList;
     
+    /**
+     Map of EPUB 2 properties for backward compatibility.
+     The keys are the properties names and the values are their
+     content.
+     eg. <meta name="cover" content="cover.png"/>
+     */
+    typedef std::map<string, string> EPUB2PropertyList;
+    
 private:
                             Package()                                   _DELETED_;
                             Package(const Package&)                     _DELETED_;
@@ -875,6 +883,13 @@ public:
     virtual void            SetMediaSupport(MediaSupportList&& list);
     
     /**
+     Returns the value (content) of the EPUB 2 property with given
+     name. Used to provide backward compatibility by host app.
+     @param name Name of the property (name attribute of the <meta> tag)
+     */
+    virtual string          EPUB2PropertyMatching(string name) const;
+    
+    /**
      Assigns a filter chain to this package.
      
      This is called automatically by Container at the end of its initialization. The
@@ -917,6 +932,7 @@ public:
 protected:
     LoadEventHandler        _loadEventHandler;      ///< The current handler for load events.
     MediaSupportList        _mediaSupport;          ///< A list of media types with their support details.
+    EPUB2PropertyList       _EPUB2Properties;       ///< A list of EPUB 2 properties for backward compatibility.
     
     void                    InitMediaSupport();
     


### PR DESCRIPTION
A common occurrence for readers is too show the cover of books in their library. Package::CoverManifestItem() provides an easy way to fetch the cover item declared in an OPF package.

This depends on the PR #206 to return the EPUB 2 cover if the EPUB 3 cover is not available. But we can decide to not support EPUB 2 cover if needed.