### PR TITLE
Fix performances of Package::ManifestItemAtRelativePath() using a cache

### DIFF
--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -90,7 +90,7 @@ PackageBase::PackageBase(const shared_ptr<Container>& owner, const string& type)
     if ( !_archive )
         throw std::invalid_argument("Owner doesn't have an archive!");
 }
-PackageBase::PackageBase(PackageBase&& o) : _archive(o._archive), _opf(std::move(o._opf)), _pathBase(std::move(o._pathBase)), _type(std::move(o._type)), _manifest(std::move(o._manifest)), _spine(std::move(o._spine))
+PackageBase::PackageBase(PackageBase&& o) : _archive(o._archive), _opf(std::move(o._opf)), _pathBase(std::move(o._pathBase)), _type(std::move(o._type)), _manifestByID(std::move(o._manifestByID)), _manifestByAbsolutePath(std::move(o._manifestByAbsolutePath)), _spine(std::move(o._spine))
 {
     o._archive = nullptr;
 }
@@ -146,8 +146,8 @@ size_t PackageBase::IndexOfSpineItemWithIDRef(const string &idref) const
 }
 shared_ptr<ManifestItem> PackageBase::ManifestItemWithID(const string &ident) const
 {
-    auto found = _manifest.find(ident);
-    if ( found == _manifest.end() )
+    auto found = _manifestByID.find(ident);
+    if ( found == _manifestByID.end() )
         return nullptr;
     
     return found->second;
@@ -163,20 +163,20 @@ string PackageBase::CFISubpathForManifestItemWithID(const string &ident) const
 const shared_vector<ManifestItem> PackageBase::ManifestItemsWithProperties(PropertyIRIList properties) const
 {
     shared_vector<ManifestItem> result;
-    for ( auto& item : _manifest )
+    for ( auto& item : _manifestByID )
     {
         if ( item.second->HasProperty(properties) )
             result.push_back(item.second);
     }
     return result;
 }
-ConstManifestItemPtr PackageBase::ManifestItemAtRelativePath(const string& path) const
+shared_ptr<ManifestItem> PackageBase::ManifestItemAtRelativePath(const string& path) const
 {
-    string absPath = _pathBase + (path[0] == '/' ? path.substr(1) : path);
-	for (auto& item : _manifest)
-	{
-		if (item.second->AbsolutePath() == absPath)
-			return item.second;
+	string absPath = _pathBase + (path[0] == '/' ? path.substr(1) : path);
+	
+	auto found = _manifestByAbsolutePath.find(absPath);
+	if (found != _manifestByAbsolutePath.end()) {
+		return found->second;
 	}
 
     // Edge case...
@@ -197,7 +197,7 @@ ConstManifestItemPtr PackageBase::ManifestItemAtRelativePath(const string& path)
     string path_(output.data(), output.length());
 
     string absPath_ = _pathBase + (path_[0] == '/' ? path_.substr(1) : path_);
-    for (auto& item : _manifest)
+    for (auto& item : _manifestByID)
     {
         string absolute = item.second->AbsolutePath();
 
@@ -569,9 +569,11 @@ bool Package::Unpack()
             if ( p->ParseXML(node) )
             {
 #if EPUB_HAVE(CXX_MAP_EMPLACE)
-                _manifest.emplace(p->Identifier(), p);
+                _manifestByID.emplace(p->Identifier(), p);
+                _manifestByAbsolutePath.emplace(p->AbsolutePath(), p);
 #else
-                _manifest[p->Identifier()] = p;
+                _manifestByID[p->Identifier()] = p;
+                _manifestByAbsolutePath[p->AbsolutePath()] = p;
 #endif
                 StoreXMLIdentifiable(p);
             }
@@ -584,7 +586,7 @@ bool Package::Unpack()
         // check fallback chains
         typedef std::map<string, bool> IdentSet;
         IdentSet idents;
-        for ( auto &pair : _manifest )
+        for ( auto &pair : _manifestByID )
         {
             ManifestItemPtr item = pair.second;
             if ( item->FallbackID().empty() )
@@ -616,8 +618,8 @@ bool Package::Unpack()
             }
             
             // validation of idref
-            auto manifestFound = _manifest.find(next->Idref());
-            if ( manifestFound == _manifest.end() )
+            auto manifestFound = _manifestByID.find(next->Idref());
+            if ( manifestFound == _manifestByID.end() )
             {
                 HandleError(EPUBError::OPFInvalidSpineIdref, _Str(next->Idref(), " does not correspond to a manifest item"));
                 continue;
@@ -981,7 +983,7 @@ bool Package::Unpack()
 	if (isEPUB3)
 	{
 		// look for EPUB3 navigation document(s)
-		for ( auto item : _manifest )
+		for ( auto item : _manifestByID )
 		{
 			if ( !item.second->HasProperty(ItemProperties::Navigation) )
 	            continue;
@@ -1752,7 +1754,7 @@ shared_ptr<MediaHandler> Package::OPFHandlerForMediaType(const string &mediaType
 const Package::StringList Package::AllMediaTypes() const
 {
     std::map<string, bool>   set;
-    for ( auto pair : _manifest )
+    for ( auto pair : _manifestByID )
     {
         set[pair.second->MediaType()] = true;
     }

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -134,7 +134,7 @@ public:
     
     ///
     /// Returns an immutable reference to the manifest table.
-    const ManifestTable&    Manifest()              const       { return _manifest; }
+    const ManifestTable&    Manifest()              const       { return _manifestByID; }
     ///
     /// Returns an immutable reference to the map of navigation tables.
     const NavigationMap&    NavigationTables()      const       { return _navigation; }
@@ -209,7 +209,7 @@ public:
 	 @result A ManifestItem pointer, or `nullptr` if no manifest item matches the path.
 	 */
 	EPUB3_EXPORT
-	ConstManifestItemPtr    ManifestItemAtRelativePath(const string& path) const;
+	shared_ptr<ManifestItem> ManifestItemAtRelativePath(const string& path) const;
     
     /// @}
     
@@ -251,16 +251,17 @@ public:
     uint32_t                SpineCFIIndex()                 const   { return _spineCFIIndex; }
     
 protected:
-    shared_ptr<Archive>			_archive;           ///< The archive from which the package was loaded.
-    shared_ptr<xml::Document>   _opf;               ///< The XML document representing the package.
-    string						_pathBase;          ///< The base path of the document within the archive.
-    string						_type;              ///< The MIME type of the package document.
-    ManifestTable				_manifest;          ///< All manifest items, indexed by unique identifier.
-    NavigationMap				_navigation;        ///< All navigation tables, indexed by type.
-    ContentHandlerMap			_contentHandlers;   ///< All installed content handlers, indexed by media-type.
-    shared_ptr<SpineItem>		_spine;             ///< The first item in the spine (SpineItems are a linked list).
-    XMLIDLookup					_xmlIDLookup;       ///< Lookup table for all items with XML ID values.
-    CollectionList              _collections;       ///< List of all parsed <collection> elements.
+    shared_ptr<Archive>       _archive;                ///< The archive from which the package was loaded.
+    shared_ptr<xml::Document> _opf;                    ///< The XML document representing the package.
+    string                    _pathBase;               ///< The base path of the document within the archive.
+    string                    _type;                   ///< The MIME type of the package document.
+    ManifestTable             _manifestByID;           ///< All manifest items, indexed by unique identifier.
+    ManifestTable             _manifestByAbsolutePath; ///< All manifest items, indexed by absolute path.
+    NavigationMap             _navigation;             ///< All navigation tables, indexed by type.
+    ContentHandlerMap         _contentHandlers;        ///< All installed content handlers, indexed by media-type.
+    shared_ptr<SpineItem>     _spine;                  ///< The first item in the spine (SpineItems are a linked list).
+    XMLIDLookup               _xmlIDLookup;            ///< Lookup table for all items with XML ID values.
+    CollectionList            _collections;            ///< List of all parsed <collection> elements.
 
 protected:
     // used to verify/correct CFIs


### PR DESCRIPTION
With a book with really large spine (> 1000 spine items), the retrieval of a manifest item by its relative path is really slow. This PR fixes this issue (#199).

There is a really interesting comment by @danielweck related to this fix here: https://github.com/readium/readium-sdk/issues/199