### PR TITLE
Add compatibility with LCP clients

### DIFF
--- a/Platform/Apple/RDServices/Main/RDContainer.h
+++ b/Platform/Apple/RDServices/Main/RDContainer.h
@@ -61,4 +61,15 @@
 
 - (instancetype)initWithDelegate:(id <RDContainerDelegate>)delegate path:(NSString *)path;
 
+/**
+ * Returns whether the given file exists in the container's archive.
+ */
+- (BOOL)fileExistsAtPath:(NSString *)relativePath;
+
+/**
+ * Read the content of the file at the relative path in the container's archive.
+ * If no file is found, returns nil.
+ */
+- (NSString *)contentsOfFileAtPath:(NSString *)relativePath encoding:(NSStringEncoding)encoding;
+
 @end

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -30,6 +30,7 @@
 #import "RDContainer.h"
 #import <ePub3/container.h>
 #import <ePub3/initialization.h>
+#import <ePub3/utilities/byte_stream.h>
 #import <ePub3/utilities/error_handler.h>
 #import "RDPackage.h"
 
@@ -113,5 +114,24 @@
 	return self;
 }
 
+- (BOOL)fileExistsAtPath:(NSString *)relativePath {
+    return m_container->FileExistsAtPath([relativePath UTF8String]);
+}
+
+- (NSString *)contentsOfFileAtPath:(NSString *)relativePath encoding:(NSStringEncoding)encoding {
+    if (![self fileExistsAtPath:relativePath])
+    	return nil;
+
+    std::unique_ptr<ePub3::ByteStream> stream = m_container->ReadStreamAtPath([relativePath UTF8String]);
+    if (stream == nullptr)
+    	return nil;
+
+    void *buffer = nullptr;
+    size_t length = stream->ReadAllBytes(&buffer);
+    std::string nativeContent((char *)buffer, length);
+    free (buffer);
+
+    return [NSString stringWithCString:nativeContent.c_str() encoding:encoding];
+}
 
 @end

--- a/ePub3/ePub/PassThroughFilter.cpp
+++ b/ePub3/ePub/PassThroughFilter.cpp
@@ -68,7 +68,7 @@ FilterContext *PassThroughFilter::InnerMakeFilterContext(ConstManifestItemPtr it
     return new PassThroughContext;
 }
 
-ByteStream::size_type PassThroughFilter::BytesAvailable(SeekableByteStream *byteStream) const
+ByteStream::size_type PassThroughFilter::BytesAvailable(FilterContext *context, SeekableByteStream *byteStream) const
 {
     return byteStream->BytesAvailable();
 }

--- a/ePub3/ePub/PassThroughFilter.h
+++ b/ePub3/ePub/PassThroughFilter.h
@@ -41,7 +41,7 @@ public:
     virtual void *FilterData(FilterContext *context, void *data, size_t len, size_t *outputLen) OVERRIDE;
     virtual OperatingMode GetOperatingMode() const OVERRIDE { return OperatingMode::SupportsByteRanges; }
 
-    virtual ByteStream::size_type BytesAvailable(SeekableByteStream *byteStream) const OVERRIDE;
+    virtual ByteStream::size_type BytesAvailable(FilterContext *context, SeekableByteStream *byteStream) const OVERRIDE;
 
     static void Register();
 

--- a/ePub3/ePub/encryption.cpp
+++ b/ePub3/ePub/encryption.cpp
@@ -32,11 +32,12 @@ bool EncryptionInfo::ParseXML(shared_ptr<xml::Node> node)
     // To add ReadiumURI namespace to process the addition information
 
 #if EPUB_COMPILER_SUPPORTS(CXX_INITIALIZER_LISTS)
-    XPathWrangler xpath(node->Document(), {{"enc", XMLENCNamespaceURI}, {"dsig", XMLDSigNamespaceURI} , { "ep", ReadiumURI }});
+    XPathWrangler xpath(node->Document(), {{"enc", XMLENCNamespaceURI}, {"dsig", XMLDSigNamespaceURI} , {"ds", XMLDSigNamespaceURI}, { "ep", ReadiumURI }});
 #else
     XPathWrangler::NamespaceList nsList;
     nsList["enc"] = XMLENCNamespaceURI;
     nsList["dsig"] = XMLDSigNamespaceURI;
+    nsList["ds"] = XMLDSigNamespaceURI;
     nsList["ep"] = ReadiumURI;
     XPathWrangler xpath(node->doc, nsList);
 #endif
@@ -46,6 +47,13 @@ bool EncryptionInfo::ParseXML(shared_ptr<xml::Node> node)
         return false;
     
     _algorithm = strings[0];
+
+    // This is used for LCP detection
+    // @see https://docs.google.com/document/d/1oNfXQZRSGqwpexLrhw0-0a2taEvVDXS9cPs8oBKLb0U/edit#bookmark=id.fdwd1ub4whd8
+    strings = xpath.Strings("./ds:KeyInfo/ds:RetrievalMethod/@Type", node);
+    if ( !strings.empty() ) {
+        _keyRetrievalMethodType = strings[0];
+    }
     
     strings = xpath.Strings("./enc:CipherData/enc:CipherReference/@URI", node);
     if ( strings.empty() )

--- a/ePub3/ePub/encryption.h
+++ b/ePub3/ePub/encryption.h
@@ -53,17 +53,16 @@ public:
     typedef string                  algorithm_type;
     
 public:
-    /// Modified by T.H. Kim on 2015-04-15
     ///
     /// Creates a new EncryptionInfo with no details filled in.
-                    EncryptionInfo(ContainerPtr owner) : OwnedBy(owner), _algorithm(), _path(), _compression_method(), _uncompressed_size() {}
+    EncryptionInfo(ContainerPtr owner) : OwnedBy(owner), _algorithm(), _path(), _compression_method(), _uncompressed_size(), _keyRetrievalMethodType() {}
     ///
     /// Copy constructor.
-                    EncryptionInfo(const EncryptionInfo& o) : OwnedBy(o), _algorithm(o._algorithm), _path(o._path), _compression_method(o._compression_method), _uncompressed_size(o._uncompressed_size) {}
+    EncryptionInfo(const EncryptionInfo& o) : OwnedBy(o), _algorithm(o._algorithm), _path(o._path), _compression_method(o._compression_method), _uncompressed_size(o._uncompressed_size), _keyRetrievalMethodType(o._keyRetrievalMethodType) {}
     ///
     /// Move constructor.
-                    EncryptionInfo(EncryptionInfo&& o) : OwnedBy(std::move(o)), _algorithm(std::move(o._algorithm)), _path(std::move(o._path)),  _compression_method(std::move(o._compression_method)), _uncompressed_size(std::move(o._uncompressed_size)) {}
-    virtual         ~EncryptionInfo() {}
+    EncryptionInfo(EncryptionInfo&& o) : OwnedBy(std::move(o)), _algorithm(std::move(o._algorithm)), _path(std::move(o._path)),  _compression_method(std::move(o._compression_method)), _uncompressed_size(std::move(o._uncompressed_size)), _keyRetrievalMethodType(std::move(o._keyRetrievalMethodType)) {}
+    virtual ~EncryptionInfo() {}
     
     
     /**
@@ -87,6 +86,15 @@ public:
     virtual void                    SetAlgorithm(algorithm_type&& alg)              { _algorithm = alg; }
     
     ///
+    /// Returns the type of the ds:RetrievalMethod of an Encrypted Key as an URI.
+    /// @see http://www.w3.org/TR/2001/WD-xmlenc-core-20010626/#sec-ds:RetrievalMethod
+    virtual const string&           KeyRetrievalMethodType()                const   { return _keyRetrievalMethodType; }
+    ///
+    /// Assigns the URI for the ds:RetrievalMethod type.
+    virtual void                    SetKeyRetrievalMethodType(const string& keyRetrievalMethodType) { _keyRetrievalMethodType = keyRetrievalMethodType; }
+    virtual void                    SetKeyRetrievalMethodType(string&& keyRetrievalMethodType)      { _keyRetrievalMethodType = keyRetrievalMethodType; }
+
+    ///
     /// Returns the Container-relative path to the encrypted resource.
     virtual const string&           Path()                                  const   { return _path; }
     ///
@@ -96,12 +104,14 @@ public:
     
     // Added by DRM inside T.H. Kim on 2015-04-15
     // Return additional information for the compressed and encrypted contents
-    virtual const string&           CompressionMethod()						const	{ return _compression_method; }
-    virtual const string&           UnCompressedSize()						const	{ return _uncompressed_size;}
+    virtual const string&           CompressionMethod()                     const   { return _compression_method; }
+    virtual const string&           UnCompressedSize()                      const   { return _uncompressed_size;}
+
 
 protected:
-    algorithm_type  _algorithm;     ///< The algorithm identifier, as per XML-ENC or OCF.
-    string          _path;          ///< The Container-relative path to an encrypted resource.
+    algorithm_type  _algorithm;              ///< The algorithm identifier, as per XML-ENC or OCF.
+    string          _keyRetrievalMethodType; ///< The method used to retrieve the encryption key (eg. used for LCP)
+    string          _path;                   ///< The Container-relative path to an encrypted resource.
 
     // Added by DRM inside T.H. Kim on 2015-04-15
     // To get additional information for the compressed and encrypted contents

--- a/ePub3/ePub/filter.h
+++ b/ePub3/ePub/filter.h
@@ -333,7 +333,7 @@ public:
     /// modes of operation.
     virtual OperatingMode GetOperatingMode() const { return OperatingMode::Standard; }
 
-    virtual ByteStream::size_type BytesAvailable(SeekableByteStream *byteStream) const { return byteStream->BytesAvailable(); };
+    virtual ByteStream::size_type BytesAvailable(FilterContext *context, SeekableByteStream *byteStream) const { return byteStream->BytesAvailable(); };
 
     ///
     /// Obtains the type-sniffer for this filter.

--- a/ePub3/ePub/filter_chain_byte_stream_range.cpp
+++ b/ePub3/ePub/filter_chain_byte_stream_range.cpp
@@ -48,7 +48,7 @@ ByteStream::size_type FilterChainByteStreamRange::BytesAvailable() _NOEXCEPT
 {
     if (m_filter)
     {
-        ByteStream::size_type size = m_filter->BytesAvailable(m_input.get());
+        ByteStream::size_type size = m_filter->BytesAvailable(m_filterContext.get(), m_input.get());
         return size;
     }
 


### PR DESCRIPTION
Minor additions to add compatibility with LCP implementations.

1. Expose the property `ds:RetrievalMethod` in `EncryptionInfo`. This property is used to detect a LCP publication, according to the [LCP specification](https://docs.google.com/document/d/1oNfXQZRSGqwpexLrhw0-0a2taEvVDXS9cPs8oBKLb0U/edit#bookmark=id.fdwd1ub4whd8).

2. Add the `FilterContext` in `ContentFilter::BytesAvailable()`. This can be used to calculate the decrypted size using the properties of the current manifest item (eg. encryption algorithm).

3. Add ability to read the content of archive files in RDContainer (iOS only). Used to load the license.lcpl file from the iOS Launcher. But could be useful outside of LCP to read any file.