### PR TITLE
Appending the try-catch to handle no-rights cases of LCP EPUB on the iOS Launcher

### DIFF
--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -66,58 +66,58 @@
 		m_delegate = delegate;
 
         
-            ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
+        ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
 
-                const char * msg = err.message();
+            const char * msg = err.message();
 
-                BOOL isSevereEpubError = NO;
-                if (err.is_spec_error()
-                        && (err.severity() == ePub3::ViolationSeverity::Critical
-                        || err.severity() == ePub3::ViolationSeverity::Major))
-                    isSevereEpubError = YES;
+            BOOL isSevereEpubError = NO;
+            if (err.is_spec_error()
+                    && (err.severity() == ePub3::ViolationSeverity::Critical
+                    || err.severity() == ePub3::ViolationSeverity::Major))
+                isSevereEpubError = YES;
 
-                BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
+            BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
 
-                return (res == YES ? true : false);
-                //return ePub3::DefaultErrorHandler(err);
-            };
-            ePub3::SetErrorHandler(sdkErrorHandler);
+            return (res == YES ? true : false);
+            //return ePub3::DefaultErrorHandler(err);
+        };
+        ePub3::SetErrorHandler(sdkErrorHandler);
 
-            ePub3::InitializeSdk();
-            ePub3::PopulateFilterManager();
-            
-            if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
-                [delegate containerRegisterContentFilters:self];
-            }
-            
-            //Content Modules for each DRM library, if any, should be registered in the function.
-            if ([delegate respondsToSelector:@selector(containerRegisterContentModules:)]) {
-                   [delegate containerRegisterContentModules:self];
-            }
-
-            m_path = path;
+        ePub3::InitializeSdk();
+        ePub3::PopulateFilterManager();
         
-            try {
-                m_container = ePub3::Container::OpenContainer(path.UTF8String);
-            } catch (std::exception& e) {
-                auto msg = e.what();
-                [self performSelectorOnMainThread:@selector(epubWarningShow:) withObject:[NSString stringWithUTF8String:msg] waitUntilDone:NO];
-                
-            } catch (...) {
-                NSLog(@"unknown exceprion");
-            }
+        if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
+            [delegate containerRegisterContentFilters:self];
+        }
+        
+        //Content Modules for each DRM library, if any, should be registered in the function.
+        if ([delegate respondsToSelector:@selector(containerRegisterContentModules:)]) {
+               [delegate containerRegisterContentModules:self];
+        }
 
-            if (m_container == nullptr) {
-                return nil;
-            }
+        m_path = path;
+    
+        try {
+            m_container = ePub3::Container::OpenContainer(path.UTF8String);
+        } catch (std::exception& e) {
+            auto msg = e.what();
+            [self performSelectorOnMainThread:@selector(epubWarningShow:) withObject:[NSString stringWithUTF8String:msg] waitUntilDone:NO];
+            
+        } catch (...) {
+            NSLog(@"unknown exceprion");
+        }
 
-            m_packageList = m_container->Packages();
-            m_packages = [[NSMutableArray alloc] initWithCapacity:4];
+        if (m_container == nullptr) {
+            return nil;
+        }
 
-            for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
-                RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
-                [m_packages addObject:package];
-            }
+        m_packageList = m_container->Packages();
+        m_packages = [[NSMutableArray alloc] initWithCapacity:4];
+
+        for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
+            RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
+            [m_packages addObject:package];
+        }
             
         
         

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -65,51 +65,40 @@
 	if (self = [super init]) {
 		m_delegate = delegate;
 
+        
+        ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
+
+            const char * msg = err.message();
+
+            BOOL isSevereEpubError = NO;
+            if (err.is_spec_error()
+                    && (err.severity() == ePub3::ViolationSeverity::Critical
+                    || err.severity() == ePub3::ViolationSeverity::Major))
+                isSevereEpubError = YES;
+
+            BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
+
+            return (res == YES ? true : false);
+            //return ePub3::DefaultErrorHandler(err);
+        };
+        ePub3::SetErrorHandler(sdkErrorHandler);
+
+        ePub3::InitializeSdk();
+        ePub3::PopulateFilterManager();
+        
+        if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
+            [delegate containerRegisterContentFilters:self];
+        }
+        
+        //Content Modules for each DRM library, if any, should be registered in the function.
+        if ([delegate respondsToSelector:@selector(containerRegisterContentModules:)]) {
+               [delegate containerRegisterContentModules:self];
+        }
+
+        m_path = path;
+    
         try {
-            ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
-
-                const char * msg = err.message();
-
-                BOOL isSevereEpubError = NO;
-                if (err.is_spec_error()
-                        && (err.severity() == ePub3::ViolationSeverity::Critical
-                        || err.severity() == ePub3::ViolationSeverity::Major))
-                    isSevereEpubError = YES;
-
-                BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
-
-                return (res == YES ? true : false);
-                //return ePub3::DefaultErrorHandler(err);
-            };
-            ePub3::SetErrorHandler(sdkErrorHandler);
-
-            ePub3::InitializeSdk();
-            ePub3::PopulateFilterManager();
-            
-            if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
-                [delegate containerRegisterContentFilters:self];
-            }
-            
-            //Content Modules for each DRM library, if any, should be registered in the function.
-            if ([delegate respondsToSelector:@selector(containerRegisterContentModules:)]) {
-                   [delegate containerRegisterContentModules:self];
-            }
-
-            m_path = path;
             m_container = ePub3::Container::OpenContainer(path.UTF8String);
-
-            if (m_container == nullptr) {
-                return nil;
-            }
-
-            m_packageList = m_container->Packages();
-            m_packages = [[NSMutableArray alloc] initWithCapacity:4];
-
-            for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
-                RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
-                [m_packages addObject:package];
-            }
-            
         } catch (std::exception& e) {
             auto msg = e.what();
             [self performSelectorOnMainThread:@selector(epubWarningShow:) withObject:[NSString stringWithUTF8String:msg] waitUntilDone:NO];
@@ -117,6 +106,20 @@
         } catch (...) {
             NSLog(@"unknown exceprion");
         }
+
+        if (m_container == nullptr) {
+            return nil;
+        }
+
+        m_packageList = m_container->Packages();
+        m_packages = [[NSMutableArray alloc] initWithCapacity:4];
+
+        for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
+            RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
+            [m_packages addObject:package];
+        }
+            
+        
         
 	}
 

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -125,7 +125,7 @@
 
 -(void)epubWarningShow:(NSString*)msg
 {
-    UIAlertView* alert = [[UIAlertView alloc] initWithTitle:@"EPUB warning:" message:msg delegate:nil cancelButtonTitle:@"ok" otherButtonTitles:nil];
+    UIAlertView* alert = [[UIAlertView alloc] initWithTitle:@"EPUB Warning:" message:msg delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
     [alert show];
 }
 

--- a/Platform/Apple/RDServices/Main/RDContainer.mm
+++ b/Platform/Apple/RDServices/Main/RDContainer.mm
@@ -66,58 +66,58 @@
 		m_delegate = delegate;
 
         
-        ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
+            ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
 
-            const char * msg = err.message();
+                const char * msg = err.message();
 
-            BOOL isSevereEpubError = NO;
-            if (err.is_spec_error()
-                    && (err.severity() == ePub3::ViolationSeverity::Critical
-                    || err.severity() == ePub3::ViolationSeverity::Major))
-                isSevereEpubError = YES;
+                BOOL isSevereEpubError = NO;
+                if (err.is_spec_error()
+                        && (err.severity() == ePub3::ViolationSeverity::Critical
+                        || err.severity() == ePub3::ViolationSeverity::Major))
+                    isSevereEpubError = YES;
 
-            BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
+                BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
 
-            return (res == YES ? true : false);
-            //return ePub3::DefaultErrorHandler(err);
-        };
-        ePub3::SetErrorHandler(sdkErrorHandler);
+                return (res == YES ? true : false);
+                //return ePub3::DefaultErrorHandler(err);
+            };
+            ePub3::SetErrorHandler(sdkErrorHandler);
 
-        ePub3::InitializeSdk();
-        ePub3::PopulateFilterManager();
-        
-        if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
-            [delegate containerRegisterContentFilters:self];
-        }
-        
-        //Content Modules for each DRM library, if any, should be registered in the function.
-        if ([delegate respondsToSelector:@selector(containerRegisterContentModules:)]) {
-               [delegate containerRegisterContentModules:self];
-        }
-
-        m_path = path;
-    
-        try {
-            m_container = ePub3::Container::OpenContainer(path.UTF8String);
-        } catch (std::exception& e) {
-            auto msg = e.what();
-            [self performSelectorOnMainThread:@selector(epubWarningShow:) withObject:[NSString stringWithUTF8String:msg] waitUntilDone:NO];
+            ePub3::InitializeSdk();
+            ePub3::PopulateFilterManager();
             
-        } catch (...) {
-            NSLog(@"unknown exceprion");
-        }
+            if ([delegate respondsToSelector:@selector(containerRegisterContentFilters:)]) {
+                [delegate containerRegisterContentFilters:self];
+            }
+            
+            //Content Modules for each DRM library, if any, should be registered in the function.
+            if ([delegate respondsToSelector:@selector(containerRegisterContentModules:)]) {
+                   [delegate containerRegisterContentModules:self];
+            }
 
-        if (m_container == nullptr) {
-            return nil;
-        }
+            m_path = path;
+        
+            try {
+                m_container = ePub3::Container::OpenContainer(path.UTF8String);
+            } catch (std::exception& e) {
+                auto msg = e.what();
+                [self performSelectorOnMainThread:@selector(epubWarningShow:) withObject:[NSString stringWithUTF8String:msg] waitUntilDone:NO];
+                
+            } catch (...) {
+                NSLog(@"unknown exceprion");
+            }
 
-        m_packageList = m_container->Packages();
-        m_packages = [[NSMutableArray alloc] initWithCapacity:4];
+            if (m_container == nullptr) {
+                return nil;
+            }
 
-        for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
-            RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
-            [m_packages addObject:package];
-        }
+            m_packageList = m_container->Packages();
+            m_packages = [[NSMutableArray alloc] initWithCapacity:4];
+
+            for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
+                RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
+                [m_packages addObject:package];
+            }
             
         
         


### PR DESCRIPTION
Dear Readium people,

We have sent a pull request(#68) for iOS Launcher to support LCP implementation.

To handle no-rights case of LCP EPUB nicely in the iOS launcher, such as expired date, invalid signature, incorrect pass-phrase etc.,  RDContainer.mm in the Readium SDK needs to have a try-catch handler with 'epubWarningShow' function.

