### PR TITLE
Fix page breaks in reflowable Epub books

### DIFF
--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		588D24201A02EF8F006A92BB /* PassThroughFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 588D241E1A02EF8F006A92BB /* PassThroughFilter.cpp */; };
 		588D24211A02EF8F006A92BB /* PassThroughFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 588D241E1A02EF8F006A92BB /* PassThroughFilter.cpp */; };
 		588D24221A02EF8F006A92BB /* PassThroughFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 588D241F1A02EF8F006A92BB /* PassThroughFilter.h */; };
+		59753FDB1C88972600EE7908 /* css_preprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 59753FD91C88972600EE7908 /* css_preprocessor.cpp */; };
+		59753FDC1C88972600EE7908 /* css_preprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 59753FDA1C88972600EE7908 /* css_preprocessor.h */; };
+		59D714EA1C8E1FCD00F6CBDA /* css_preprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 59753FD91C88972600EE7908 /* css_preprocessor.cpp */; };
 		834B09011A0BD015006AEB12 /* filter_chain_byte_stream_range.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A250D33BAFB8E8EAEF5FE5B5 /* filter_chain_byte_stream_range.cpp */; };
 		834B09021A0BD018006AEB12 /* filter_chain_byte_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A250DFDBD90C7E9C632B1E00 /* filter_chain_byte_stream.cpp */; };
 		850B1AE916A75AC600619C3C /* TestData in CopyFiles */ = {isa = PBXBuildFile; fileRef = 850B1AE816A75AB000619C3C /* TestData */; };
@@ -447,6 +450,8 @@
 		1EFA3ACA17AB0BEF003A4BC2 /* filter_manager_impl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = filter_manager_impl.cpp; sourceTree = "<group>"; };
 		588D241E1A02EF8F006A92BB /* PassThroughFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PassThroughFilter.cpp; sourceTree = "<group>"; };
 		588D241F1A02EF8F006A92BB /* PassThroughFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PassThroughFilter.h; sourceTree = "<group>"; };
+		59753FD91C88972600EE7908 /* css_preprocessor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = css_preprocessor.cpp; sourceTree = "<group>"; };
+		59753FDA1C88972600EE7908 /* css_preprocessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = css_preprocessor.h; sourceTree = "<group>"; };
 		850B1AE816A75AB000619C3C /* TestData */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TestData; path = ../../TestData; sourceTree = "<group>"; };
 		A250D0D74FF2AD1AB643D2FA /* media-overlays_smil_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "media-overlays_smil_data.h"; sourceTree = "<group>"; };
 		A250D119DCB804938466E3D6 /* media-overlays_smil_model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "media-overlays_smil_model.cpp"; sourceTree = "<group>"; };
@@ -1131,6 +1136,8 @@
 				AB95448216BAD32000EFD2FD /* switch_preprocessor.h */,
 				AB95448616BAF11000EFD2FD /* object_preprocessor.cpp */,
 				AB95448716BAF11000EFD2FD /* object_preprocessor.h */,
+				59753FD91C88972600EE7908 /* css_preprocessor.cpp */,
+				59753FDA1C88972600EE7908 /* css_preprocessor.h */,
 			);
 			name = "Content Preprocessing";
 			sourceTree = "<group>";
@@ -1837,6 +1844,7 @@
 				ABA4BA5D16A7414000161B77 /* logging.h in Headers */,
 				ABA4BA5F16A7414000161B77 /* scoped_ptr.h in Headers */,
 				ABA4BA6316A7414000161B77 /* string16.h in Headers */,
+				59753FDC1C88972600EE7908 /* css_preprocessor.h in Headers */,
 				ABA4BA6716A7414000161B77 /* gurl.h in Headers */,
 				ABA4BA6D16A7414000161B77 /* url_canon.h in Headers */,
 				ABA4BA7916A7414000161B77 /* url_canon_icu.h in Headers */,
@@ -2029,6 +2037,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59D714EA1C8E1FCD00F6CBDA /* css_preprocessor.cpp in Sources */,
 				ABA4BAEF16ADF64400161B77 /* string16.cc in Sources */,
 				ABA4BAF016ADF64400161B77 /* gurl.cc in Sources */,
 				AB5284D417CBC395003D7BBF /* CPUCacheUtils.c in Sources */,
@@ -2305,6 +2314,7 @@
 				1ED0083B17A9B7F800819EBD /* byte_buffer.cpp in Sources */,
 				1ED0084417A9D6E800819EBD /* filter_manager.cpp in Sources */,
 				A250D0731D530005B0FFF5D5 /* media-overlays_smil_model.cpp in Sources */,
+				59753FDB1C88972600EE7908 /* css_preprocessor.cpp in Sources */,
 				A250DCD0523C05493141CE3B /* media-overlays_smil_data.cpp in Sources */,
 				1ED0084817A9DC6F00819EBD /* initialization.cpp in Sources */,
 				1EFA3ACB17AB0BEF003A4BC2 /* filter_manager_impl.cpp in Sources */,

--- a/ePub3/ePub/PassThroughFilter.cpp
+++ b/ePub3/ePub/PassThroughFilter.cpp
@@ -40,8 +40,8 @@ bool PassThroughFilter::SniffPassThroughContent(ConstManifestItemPtr item)
 	// you can use the following commented out code for doing that. The code below will make this filter
 	// apply when a media resource is being read.
 	//
-    // auto mediaType = item->MediaType();
-    // return (mediaType == "audio/mp4" || mediaType == "audio/mpeg" || mediaType == "video/mp4" || mediaType == "video/mpeg");
+    auto mediaType = item->MediaType();
+    return (mediaType == "application/xhtml+xml" || mediaType == "text/html" || mediaType == "text/css");
 
 	return false;
 }

--- a/ePub3/ePub/css_preprocessor.cpp
+++ b/ePub3/ePub/css_preprocessor.cpp
@@ -1,0 +1,136 @@
+//
+//  css_preprocessor.cpp
+//  ePub3
+//
+//  Created by Olivier Körner on 2016-03-08.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  Licensed under Gnu Affero General Public License Version 3 (provided, notwithstanding this notice,
+//  Readium Foundation reserves the right to license this material under a different separate license,
+//  and if you have done so, the terms of that separate license control and the following references
+//  to GPL do not apply).
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+//  Affero General Public License as published by the Free Software Foundation, either version 3 of
+//  the License, or (at your option) any later version. You should have received a copy of the GNU
+//  Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "css_preprocessor.h"
+#include "package.h"
+#include "filter_manager.h"
+
+static const REGEX_NS::regex::flag_type regexFlags(REGEX_NS::regex::ECMAScript|REGEX_NS::regex::optimize|REGEX_NS::regex::icase);
+static const REGEX_NS::regex reEscaper("\\\\\\.\\(\\)\\[\\]\\$\\^\\*\\+\\?\\:\\=\\|", regexFlags);
+
+EPUB3_BEGIN_NAMESPACE
+
+static REGEX_NS::regex CSSMatcher("page\\-break\\-(after|before|inside) *\\: *(always|avoid|left|right)", regexFlags);
+static REGEX_NS::regex StyleAttributeMatcher("<[^>]+style=\\\"([^\\\"]*)\"", regexFlags);
+static REGEX_NS::regex StyleTagMatcher("<style>.*?<\\/style>", regexFlags);
+
+static const std::string PageBreakReplacement ="-webkit-column-break-$1: $2";
+
+//CSSFilterContext::CSSFilterContext(ConstManifestItemPtr item) {
+//    this->setCSS(item->MediaType() == "text/css");
+//}
+
+bool CSSPreprocessor::ShouldApply(ConstManifestItemPtr item)
+{
+    auto mediaType = item->MediaType();
+    std::cout << "CSSPreprocessor ShouldApply " << mediaType << " " << item->Href();
+    return (mediaType == "application/xhtml+xml" || mediaType == "text/html" || mediaType == "text/css");
+}
+
+ContentFilterPtr CSSPreprocessor::CSSFilterFactory(ConstPackagePtr package)
+{
+    return New(package);
+}
+
+void CSSPreprocessor::Register()
+{
+    FilterManager::Instance()->RegisterFilter("CSSPreprocessor", ValidationComplete, CSSFilterFactory);
+}
+
+CSSPreprocessor::CSSPreprocessor(ConstPackagePtr pkg) : ContentFilter(ShouldApply)
+{
+}
+
+
+void* CSSPreprocessor::FilterData(FilterContext* context, void *data, size_t len, size_t *outputLen)
+{
+    CSSFilterContext* p = dynamic_cast<CSSFilterContext*>(context);
+    bool isCSS = p->isCSS();
+    char* input = reinterpret_cast<char*>(data);
+    
+    std::string output;
+    if (isCSS) {
+        output = REGEX_NS::regex_replace(input, CSSMatcher, PageBreakReplacement);
+    }
+    else
+    {
+        char* input = reinterpret_cast<char*>(data);
+        std::string toutput;
+        // find each `style` tags
+        REGEX_NS::cregex_iterator pos(input, input+len, StyleTagMatcher);
+        REGEX_NS::cregex_iterator end;
+        if ( pos == end )
+        {
+            toutput.assign(input, len);
+        }
+        else
+        {
+            while (pos != end) {
+                std::cout << "style tag prefix" << pos->prefix();
+                toutput += pos->prefix();
+                
+                std::string styleout = pos->str();
+                std::cout << "style match" << pos->str();
+                toutput += REGEX_NS::regex_replace(pos->str(), CSSMatcher, PageBreakReplacement);
+                
+                auto here = pos++;
+                if ( pos == end )
+                    toutput += here->suffix();
+            }
+        }
+        
+        // find each `style` attributes
+        REGEX_NS::sregex_iterator apos(toutput.begin(), toutput.end(), StyleAttributeMatcher);
+        REGEX_NS::sregex_iterator aend;
+        if ( apos == aend )
+        {
+            output = toutput;        // no match == no change
+        }
+        else {
+            while (apos != aend) {
+                std::cout << "style tag prefix" << apos->prefix();
+                output += apos->prefix();
+                
+                std::string styleout = apos->str();
+                output += REGEX_NS::regex_replace(pos->str(), CSSMatcher, PageBreakReplacement);
+                
+                auto here = apos++;
+                if ( apos == aend )
+                    output += here->suffix();
+            }
+        }
+        
+    }
+
+    *outputLen = output.size();
+    if ( output.size() < len )
+    {
+        // use the incoming buffer directly
+        output.copy(input, output.size());
+        return input;
+    }
+    
+    // allocate an output buffer
+    char* result = new char[output.size()];
+    output.copy(result, output.size());
+    return result;
+}
+
+EPUB3_END_NAMESPACE

--- a/ePub3/ePub/css_preprocessor.h
+++ b/ePub3/ePub/css_preprocessor.h
@@ -3,8 +3,20 @@
 //  ePub3
 //
 //  Created by Olivier Körner on 03/03/2016.
-//  Copyright © 2016 The Readium Foundation and contributors. All rights reserved.
+//  Copyright (c) 2016 The Readium Foundation and contributors. All rights reserved.
 //
+//  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  Licensed under Gnu Affero General Public License Version 3 (provided, notwithstanding this notice,
+//  Readium Foundation reserves the right to license this material under a different separate license,
+//  and if you have done so, the terms of that separate license control and the following references
+//  to GPL do not apply).
+//
+//  This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+//  Affero General Public License as published by the Free Software Foundation, either version 3 of
+//  the License, or (at your option) any later version. You should have received a copy of the GNU
+//  Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef __ePub3__css_preprocessor_hpp
 #define __ePub3__css_preprocessor_hpp

--- a/ePub3/ePub/initialization.cpp
+++ b/ePub3/ePub/initialization.cpp
@@ -25,6 +25,7 @@
 #include <ePub3/font_obfuscation.h>
 #include <ePub3/switch_preprocessor.h>
 #include <ePub3/object_preprocessor.h>
+#include <ePub3/css_preprocessor.h>
 #include <ePub3/PassThroughFilter.h>
 
 EPUB3_BEGIN_NAMESPACE
@@ -47,9 +48,10 @@ void PopulateFilterManager()
 		// simply uncomment the line below. Also take a look at the file PassThroughFilter.cpp
 		// to see if the class is enabling itself.
 		//
-        // PassThroughFilter::Register();
+        PassThroughFilter::Register();
         SwitchPreprocessor::Register();
         ObjectPreprocessor::Register();
+        CSSPreprocessor::Register();
     });
 }
 

--- a/ePub3/ePub/initialization.cpp
+++ b/ePub3/ePub/initialization.cpp
@@ -48,7 +48,7 @@ void PopulateFilterManager()
 		// simply uncomment the line below. Also take a look at the file PassThroughFilter.cpp
 		// to see if the class is enabling itself.
 		//
-        PassThroughFilter::Register();
+        //PassThroughFilter::Register();
         SwitchPreprocessor::Register();
         ObjectPreprocessor::Register();
         CSSPreprocessor::Register();


### PR DESCRIPTION
CSS properties `page-break-inside/after/before` with values `always/auto/avoid` are sometimes used in Epub books to force or prevent text to the next page. This is a print-only CSS property and as such it's rendered in the webview.

By adding a CSS preprocessor content filter in the SDK, all occurences of `page-break-*` in CSS stylesheets and style elements and attributes in HTML content are replaced by matching `column-break-*`,  enforcing or preventing the page breaks accordingly in the reader. 

readium/readium-shared-js#127

![page-breaks-demo](https://cloud.githubusercontent.com/assets/587255/14180550/d6f6621a-f763-11e5-922a-2efc8fa53d20.png)
