### PR TITLE
Add method getCoverManifestItem

### DIFF
--- a/Platform/Android/epub3/src/main/jni/packagejni.cpp
+++ b/Platform/Android/epub3/src/main/jni/packagejni.cpp
@@ -654,6 +654,25 @@ JNIEXPORT jobject JNICALL Java_org_readium_sdk_android_Package_nativeGetSpineIte
 
 	return spineItemList;
 }
+JNIEXPORT jobject JNICALL Java_org_readium_sdk_android_Package_nativeGetCoverManifestItem
+        (JNIEnv* env, jobject thiz, jlong pckgPtr)
+{
+    std::shared_ptr<ePub3::ManifestItem> item = PCKG(pckgPtr)->CoverManifestItem();
+    if (item == nullptr)
+        return nullptr;
+
+    jni::StringUTF hr(env, (std::string&) item->Href().stl_str());
+    jstring href = (jstring) hr;
+    jni::StringUTF mt(env, (std::string&) item->MediaType().stl_str());
+    jstring mediaType = (jstring) mt;
+
+    jobject manifestItem = env->CallStaticObjectMethod(javaJavaObjectsFactoryClass, createManifestItem_ID,
+                                                       href, mediaType);
+
+    env->DeleteLocalRef(href);
+    env->DeleteLocalRef(mediaType);
+    return manifestItem;
+}
 JNIEXPORT jobject JNICALL Java_org_readium_sdk_android_Package_nativeGetTableOfContents
 		(JNIEnv* env, jobject thiz, jlong pckgPtr)
 {

--- a/Platform/Android/epub3/src/main/jni/packagejni.h
+++ b/Platform/Android/epub3/src/main/jni/packagejni.h
@@ -171,6 +171,12 @@ JNIEXPORT jstring JNICALL Java_org_readium_sdk_android_Package_nativeGetModifica
 JNIEXPORT jobject JNICALL Java_org_readium_sdk_android_Package_nativeGetSubjects(JNIEnv* env, jobject thiz, jlong pckgPtr);
 /*
  * Class:     org_readium_sdk_android_Package
+ * Method:    nativeGetCoverManifestItem
+ * Signature: (J)Ljava/util/ManifestItem;
+ */
+JNIEXPORT jobject JNICALL Java_org_readium_sdk_android_Package_nativeGetCoverManifestItem(JNIEnv* env, jobject thiz, jlong pckgPtr);
+/*
+ * Class:     org_readium_sdk_android_Package
  * Method:    nativeGetManifestTable
  * Signature: (J)Ljava/util/List;
  */

--- a/Platform/Android/lib/src/main/java/org/readium/sdk/android/Package.java
+++ b/Platform/Android/lib/src/main/java/org/readium/sdk/android/Package.java
@@ -82,6 +82,7 @@ public class Package {
 	private List<String> authorList;
 	private List<String> subjects;
 	private List<SpineItem> spineItems;
+    private ManifestItem coverManifestItem;
 	private NavigationTable tableOfContents;
 	private NavigationTable listOfFigures;
 	private NavigationTable listOfIllustrations;
@@ -163,6 +164,7 @@ public class Package {
 		authorList = nativeGetAuthorList(__nativePtr);
 		subjects = nativeGetSubjects(__nativePtr);
 		spineItems = nativeGetSpineItems(__nativePtr);
+        coverManifestItem = nativeGetCoverManifestItem(__nativePtr);
 		manifestTable = nativeGetManifestTable(__nativePtr);
 		smilDataJson = nativeGetSmilDataAsJson(__nativePtr);
 		rendition_layout = nativeGetProperty(__nativePtr, "layout", "rendition");
@@ -390,6 +392,13 @@ public class Package {
 		}
 		return null;
 	}
+    
+    /**
+     * Returns manifest item cover.
+     */
+    public ManifestItem getCoverManifestItem() {
+        return coverManifestItem;
+    }
 
     public PackageResource getResourceAtRelativePath(String relativePath) {
         return new PackageResource(this, relativePath);
@@ -514,7 +523,8 @@ public class Package {
 	private native List<String> nativeGetSubjects(long nativePtr);
 	private native List<SpineItem> nativeGetSpineItems(long nativePtr);
 	private native String nativeGetProperty(long nativePtr, String propertyName, String prefix);
-	
+	private native ManifestItem nativeGetCoverManifestItem(long nativePtr);
+
 	/*
 	 * Navigation tables
 	 */


### PR DESCRIPTION
A method exist in sdk/ePub3/package.cpp for get cover item from manifest, but this method not implemented in jni for java side.