### PR TITLE
Added methods to RDPackageResourceServer to stop/restart the HTTP server

### DIFF
--- a/Platform/Apple/RDServices/Main/RDPackageResourceServer.h
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceServer.h
@@ -69,6 +69,9 @@
 @property (nonatomic, readonly) NSData *specialPayloadAnnotationsCSS;
 @property (nonatomic, readonly) NSData *specialPayloadMathJaxJS;
 
+- (BOOL)startHTTPServer;
+- (void)stopHTTPServer;
+
 - (void)executeJavaScript:(NSString *)javaScript;
 
 - (instancetype)

--- a/Platform/Apple/RDServices/Main/RDPackageResourceServer.m
+++ b/Platform/Apple/RDServices/Main/RDPackageResourceServer.m
@@ -41,6 +41,7 @@ static id m_resourceLock = nil;
 	@private RDPackage *m_package;
 	@private NSData *m_specialPayloadAnnotationsCSS;
 	@private NSData *m_specialPayloadMathJaxJS;
+    @private UInt16 m_serverPort;
 }
 
 @end
@@ -94,16 +95,10 @@ static id m_resourceLock = nil;
 		m_httpServer.documentRoot = @"";
 		[m_httpServer setConnectionClass:[RDPackageResourceConnection class]];
 
-		NSError *error = nil;
-		BOOL success = [m_httpServer start:&error];
-
-		if (!success || error != nil) {
-			if (error != nil) {
-				NSLog(@"Could not start the HTTP server! %@", error);
-			}
-
-			return nil;
-		}
+        BOOL success = [self startHTTPServer];
+        if (!success) {
+            return nil;
+        }
 
 		[RDPackageResourceConnection setPackageResourceServer:self];
 	}
@@ -121,5 +116,29 @@ static id m_resourceLock = nil;
 	return m_resourceLock;
 }
 
+- (BOOL)startHTTPServer {
+    if (m_serverPort > 0) {
+        [m_httpServer setPort:m_serverPort];
+    }
+    
+    NSError *error = nil;
+    BOOL success = [m_httpServer start:&error];
+    if (!success || error != nil) {
+        if (error != nil) {
+            NSLog(@"Could not start the HTTP server! %@", error);
+        }
+        return NO;
+    }
+    
+    if (m_serverPort == 0) {
+        m_serverPort = [m_httpServer listeningPort];
+    }
+    
+    return success;
+}
+
+- (void)stopHTTPServer {
+    [m_httpServer stop];
+}
 
 @end


### PR DESCRIPTION
The port is saved so the server starts with the port that was used
when it was stopped.
Related to https://github.com/readium/SDKLauncher-iOS/issues/81
https://github.com/readium/SDKLauncher-iOS/pull/82