### PR TITLE
IOS-12597: Do not parse smil if creating document failed

### DIFF
--- a/ePub3/ePub/media-overlays_smil_model.cpp
+++ b/ePub3/ePub/media-overlays_smil_model.cpp
@@ -413,6 +413,8 @@ public:
                 if (!bool(doc))
                 {
                     HandleError(EPUBError::MediaOverlayCannotParseSMILXML, _Str("Cannot parse XML: ", item->Href().c_str()));
+
+                    return 0;
                 }
 
 #if EPUB_COMPILER_SUPPORTS(CXX_INITIALIZER_LISTS)


### PR DESCRIPTION
Do not continue rest of work if parsing smil(s) failed to avoid the crash later.