### PR TITLE
AN-8945: Call reset() to delete ByteStream in ResourceStream

### DIFF
--- a/Platform/Android/epub3/src/main/jni/resource_stream.cpp
+++ b/Platform/Android/epub3/src/main/jni/resource_stream.cpp
@@ -45,9 +45,8 @@ std::size_t ResourceStream::getBufferSize() {
 }
 
 ResourceStream::~ResourceStream() {
-	ePub3::ByteStream* reader = _ptr.get();
-	reader->Close();
-	_ptr.reset();
+	ePub3::ByteStream* reader = _ptr.release();
+	delete reader;
 }
 
 #ifdef __cplusplus

--- a/Platform/Android/epub3/src/main/jni/resource_stream.cpp
+++ b/Platform/Android/epub3/src/main/jni/resource_stream.cpp
@@ -47,7 +47,7 @@ std::size_t ResourceStream::getBufferSize() {
 ResourceStream::~ResourceStream() {
 	ePub3::ByteStream* reader = _ptr.get();
 	reader->Close();
-	_ptr.release();
+	_ptr.reset();
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Original implementation will cause huge memory leakages when Java layer acquire a resource, the ByteStream is never been released due to calling release() won't delete the memory allocation.
I'd change the _ptr.release() to _ptr.reset() to unlink the pointer and release the memory of ByteStream.