### PR TITLE
Spine items rejecting property attributes

### DIFF
--- a/ePub3/ePub/spine.cpp
+++ b/ePub3/ePub/spine.cpp
@@ -38,6 +38,7 @@ const IRI SpineItem::PageSpreadLeftPropertyIRI("http://idpf.org/epub/vocab/packa
 
 SpineItem::SpineItem(const shared_ptr<Package>& owner) : OwnedBy(owner), PropertyHolder(owner), _idref(), _linear(true), _next(), _prev()
 {
+    RegisterPrefixIRIStem("rendition", "http://www.idpf.org/vocab/rendition/#");
 }
 SpineItem::SpineItem(SpineItem&& o) : OwnedBy(std::move(o)), PropertyHolder(std::move(o)), XMLIdentifiable(std::move(o)), _idref(std::move(o._idref)), _linear(o._linear), _prev(std::move(o._prev)), _next(std::move(o._next))
 {


### PR DESCRIPTION
Related to: 9a9c8d84 where the 'rendition' prefix was disabled
The XML parsing runs fine, extracting the property string, but when creating the IRI, there's a whitelist for acceptable IRI prefixes it seems and the default has 'rendition' commented out. The proposed solution is to specifically enable this for SpineItem since it seems there are previous issues with enabling it in the default whitelist.